### PR TITLE
update include path for ROCm 5.2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,6 +64,14 @@ LAPACK++ specific options include (all values are case insensitive):
         Again, there is usually no need to specify this. E.g.,
         cmake -DLAPACK_LIBRARIES='-lopenblas' ..
 
+    gpu_backend
+        BLAS++ must be built with the same GPU backend.
+        auto            auto-detect CUDA, HIP/ROCm, or oneMKL (default)
+        cuda            build with CUDA support
+        hip             build with HIP/ROCm support
+        onemkl          build with SYCL and oneMKL support (not yet implemented)
+        none            do not build with GPU backend
+
     color
         Whether to use ANSI colors in output. One of:
         auto            uses color if output is a TTY

--- a/config/rocblas.cc
+++ b/config/rocblas.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, University of Tennessee. All rights reserved.
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
@@ -8,7 +8,13 @@
 #endif
 
 #include <hip/hip_runtime.h>
-#include <rocblas.h>
+
+// Headers moved in ROCm 5.2
+#if HIP_VERSION >= 50200000
+    #include <rocblas/rocblas.h>
+#else
+    #include <rocblas.h>
+#endif
 
 #include <stdexcept>
 #include <cassert>

--- a/src/rocm/rocm_common.hh
+++ b/src/rocm/rocm_common.hh
@@ -1,0 +1,20 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef LAPACK_ROCM_COMMON_H
+#define LAPACK_ROCM_COMMON_H
+
+#include "lapack/device.hh"
+
+#include <hip/hip_runtime.h>
+
+// Headers moved in ROCm 5.2
+#if HIP_VERSION >= 50200000
+    #include <rocsolver/rocsolver.h>
+#else
+    #include <rocsolver.h>
+#endif
+
+#endif // LAPACK_ROCM_COMMON_H

--- a/src/rocm/rocm_geqrf.cc
+++ b/src/rocm/rocm_geqrf.cc
@@ -7,9 +7,7 @@
 
 #if defined(LAPACK_HAVE_ROCBLAS)
 
-#include "lapack/device.hh"
-
-#include <rocsolver.h>
+#include "rocm_common.hh"
 
 //==============================================================================
 namespace lapack {

--- a/src/rocm/rocm_getrf.cc
+++ b/src/rocm/rocm_getrf.cc
@@ -7,9 +7,7 @@
 
 #if defined(LAPACK_HAVE_ROCBLAS)
 
-#include "lapack/device.hh"
-
-#include <rocsolver.h>
+#include "rocm_common.hh"
 
 //==============================================================================
 namespace lapack {

--- a/src/rocm/rocm_potrf.cc
+++ b/src/rocm/rocm_potrf.cc
@@ -7,9 +7,7 @@
 
 #if defined(LAPACK_HAVE_ROCBLAS)
 
-#include "lapack/device.hh"
-
-#include <rocsolver.h>
+#include "rocm_common.hh"
 
 //==============================================================================
 // todo: put into BLAS++ header somewhere.


### PR DESCRIPTION
Resolves deprecated warnings. Cf. https://bitbucket.org/icl/blaspp/issues/20/rocm-520-deprecated-header