### PR TITLE
use python3

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,10 +26,12 @@ else ifneq ($(findstring clean,$(MAKECMDGOALS)),clean)
     include make.inc
 endif
 
+python ?= python3
+
 force: ;
 
 make.inc:
-	python configure.py
+	${python} configure.py
 
 # Defaults if not given in make.inc. GNU make doesn't have defaults for these.
 RANLIB   ?= ranlib
@@ -242,7 +244,7 @@ test/check: check
 
 # 'make check' tests subset of routines, to avoid spurious failures
 check: tester
-	cd test; python run_tests.py --quick \
+	cd test; ${python} run_tests.py --quick \
 		gesv getrf posv potrf geqrf ungqr gels \
 		geev heev heevd heevr gesvd
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ LAPACK++ specific options include (all values are case insensitive):
 With Makefile, options are specified as environment variables or on the
 command line using `option=value` syntax, such as:
 
-    python configure.py lapack=generic
+    python3 configure.py lapack=generic
 
 With CMake, options are specified on the command line using
 `-Doption=value` syntax (not as environment variables), such as:
@@ -112,7 +112,7 @@ Available targets:
 
     make config [options]
     or
-    python configure.py [options]
+    python3 configure.py [options]
 
 Runs the `configure.py` script to detect your compiler and library properties,
 then creates a make.inc configuration file. You can also manually edit the
@@ -133,7 +133,7 @@ options include:
 
 These can be set in your environment or on the command line, e.g.,
 
-    python configure.py CXX=g++ prefix=/usr/local
+    python3 configure.py CXX=g++ prefix=/usr/local
 
 Configure assumes environment variables are set so your compiler can find BLAS
 and LAPACK libraries. For example:

--- a/config/config.py
+++ b/config/config.py
@@ -994,9 +994,9 @@ def init( namespace, prefix='/usr/local' ):
         txt += '''
 MacOS System Integrity Protection (SIP) prevents configure.py from inheriting
 $DYLD_LIBRARY_PATH. Using
-    python configure.py
-directly (not via make), with a 3rd party python from python.org, Homebrew, etc.
-(i.e., not /usr/bin/python), will allow $DYLD_LIBRARY_PATH to be inherited.
+    python3 configure.py
+directly (not via make), with a 3rd party python3 from python.org, Homebrew, etc.
+(i.e., not /usr/bin/python3), will allow $DYLD_LIBRARY_PATH to be inherited.
 '''
         txt = font.red( txt )
         txt += '-'*80

--- a/configure.py
+++ b/configure.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 #
-# Usage: python configure.py [--interactive]
+# Usage: python3 configure.py [--interactive]
 
 from __future__ import print_function
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -248,7 +248,7 @@ if (lapackpp_is_project)
     add_custom_target(
         "check"
         COMMAND
-            python run_tests.py --quick
+            python3 run_tests.py --quick
                 gesv getrf posv potrf geqrf ungqr gels
                 geev heev heevd heevr gesvd
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/equation.py
+++ b/tools/equation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Attempts to find equations in Doxygen code and replace them with $...$.
 # For instance:

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Usage: ./gen.py basenames
 # where basenames are like getrf, gesv, posv, ...

--- a/tools/header_gen.py
+++ b/tools/header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Generate C prototypes for the LAPACK Fortran functions by parsing

--- a/tools/regen.py
+++ b/tools/regen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Usage: ./regen.py
 #

--- a/tools/wrapper_gen.py
+++ b/tools/wrapper_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 wrapper_gen.py generates C++ wrappers, header prototypes, and testers for the


### PR DESCRIPTION
Python 3 was released in 2008. After 14 years, let's kill Python 2, which [officially expired 2020-01-01](https://www.python.org/doc/sunset-python-2/).