### PR TITLE
test: change 2-line headers to 1-line headers and adjust widths

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -21,6 +21,12 @@ using testsweeper::ansi_bold;
 using testsweeper::ansi_red;
 using testsweeper::ansi_normal;
 
+const double no_data = testsweeper::no_data_flag;
+
+const ParamType PT_Value  = ParamType::Value;
+const ParamType PT_List   = ParamType::List;
+const ParamType PT_Output = ParamType::Output;
+
 // -----------------------------------------------------------------------------
 // each section must have a corresponding entry in section_names
 enum Section {
@@ -536,29 +542,43 @@ Params::Params():
 
     // ----- output parameters
     // min, max are ignored
-    //           name,                    w, p, type,              default,               min, max, help
-    error      ( "error",                 9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error" ),
-    error2     ( "error2",                9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error" ),
-    error3     ( "error3",                9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error" ),
-    error4     ( "error4",                9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error" ),
-    error5     ( "error5",                9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error" ),
-    ortho      ( "ortho.\nerror",         9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "orthogonality error" ),
-    ortho_U    ( "U ortho.\nerror",       9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "U orthogonality error" ),
-    ortho_V    ( "V ortho.\nerror",       9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "V orthogonality error" ),
-    error_sigma( "Sigma\nerror",          9, 2, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Sigma error" ),
+    //          name,            w, p, type,      default, min, max, help
+    // error: %8.2e allows 9.99e-99
+    error     ( "error",         8, 2, PT_Output, no_data, 0, 0, "numerical error" ),
+    error2    ( "error2",        8, 2, PT_Output, no_data, 0, 0, "numerical error 2" ),
+    error3    ( "error3",        8, 2, PT_Output, no_data, 0, 0, "numerical error 3" ),
+    error4    ( "error4",        8, 2, PT_Output, no_data, 0, 0, "numerical error 4" ),
+    error5    ( "error5",        8, 2, PT_Output, no_data, 0, 0, "numerical error 5" ),
+    ortho     ( "orth.",         8, 2, PT_Output, no_data, 0, 0, "orthogonality error" ),
+    ortho_U   ( "U orth.",       8, 2, PT_Output, no_data, 0, 0, "U orthogonality error" ),
+    ortho_V   ( "V orth.",       8, 2, PT_Output, no_data, 0, 0, "V orthogonality error" ),
 
-    time      ( "LAPACK++\ntime (s)",    10, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution" ),
-    gflops    ( "LAPACK++\nGflop/s",     11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate" ),
-    gbytes    ( "LAPACK++\nGbyte/s",     11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate" ),
-    iters     ( "LAPACK++\niters",        6,    ParamType::Output,                     0,   0,   0, "iterations to solution" ),
+    // time:    %9.3f allows 99999.999 s = 2.9 days (ref headers need %12)
+    // gflops: %12.3f allows 99999999.999 Gflop/s = 100 Pflop/s
+    time      ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution" ),
+    gflops    ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate" ),
+    gbytes    ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate" ),
+    iters     ( "iters",         5,    PT_Output, 0,       0, 0, "iterations to solution" ),
 
-    ref_time  ( "Ref.\ntime (s)",        10, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference time to solution" ),
-    ref_gflops( "Ref.\nGflop/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference Gflop/s rate" ),
-    ref_gbytes( "Ref.\nGbyte/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference Gbyte/s rate" ),
-    ref_iters ( "Ref.\niters",            6,    ParamType::Output,                     0,   0,   0, "reference iterations to solution" ),
+    time2     ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution (2)" ),
+    gflops2   ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate (2)" ),
+    gbytes2   ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate (2)" ),
+
+    time3     ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution (3)" ),
+    gflops3   ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate (3)" ),
+    gbytes3   ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate (3)" ),
+
+    time4     ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution (4)" ),
+    gflops4   ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate (4)" ),
+    gbytes4   ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate (4)" ),
+
+    ref_time  ( "ref time (s)", 12, 3, PT_Output, no_data, 0, 0, "reference time to solution" ),
+    ref_gflops( "ref gflop/s",  12, 3, PT_Output, no_data, 0, 0, "reference Gflop/s rate" ),
+    ref_gbytes( "ref gbyte/s",  12, 3, PT_Output, no_data, 0, 0, "reference Gbyte/s rate" ),
+    ref_iters ( "ref iters",     9,    PT_Output, 0,       0, 0, "reference iterations to solution" ),
 
     // default -1 means "no check"
-    //          name,     w, type,              def, min, max, help
+    //          name,     w, type,          default, min, max, help
     okay      ( "status", 6, ParamType::Output,  -1,   0,   0, "success indicator" ),
     msg       ( "",       1, ParamType::Output,  "",           "error message" )
 {

--- a/test/test.hh
+++ b/test/test.hh
@@ -108,12 +108,23 @@ public:
     testsweeper::ParamScientific ortho;
     testsweeper::ParamScientific ortho_U;
     testsweeper::ParamScientific ortho_V;
-    testsweeper::ParamScientific error_sigma;
 
     testsweeper::ParamDouble     time;
     testsweeper::ParamDouble     gflops;
     testsweeper::ParamDouble     gbytes;
     testsweeper::ParamInt        iters;
+
+    testsweeper::ParamDouble     time2;
+    testsweeper::ParamDouble     gflops2;
+    testsweeper::ParamDouble     gbytes2;
+
+    testsweeper::ParamDouble     time3;
+    testsweeper::ParamDouble     gflops3;
+    testsweeper::ParamDouble     gbytes3;
+
+    testsweeper::ParamDouble     time4;
+    testsweeper::ParamDouble     gflops4;
+    testsweeper::ParamDouble     gbytes4;
 
     testsweeper::ParamDouble     ref_time;
     testsweeper::ParamDouble     ref_gflops;

--- a/test/test_geev.cc
+++ b/test/test_geev.cc
@@ -49,11 +49,17 @@ void test_geev_work( Params& params, bool run )
     //params.ref_gflops();
     //params.gflops();
 
-    params.error .name( "A' Vl-Vl W'\nerror" );
-    params.error2.name( "Vl(j) norm\nerror" );
-    params.error3.name( "A Vr-Vr W\nerror" );
-    params.error4.name( "Vr(j) norm\nerror" );
-    params.error5.name( "W - Wref\nerror" );
+    params.error .name( "A' Vl - Vl W'" );
+    params.error2.name( "Vl(j) norm" );
+    params.error3.name( "A Vr - Vr W" );
+    params.error4.name( "Vr(j) norm" );
+    params.error5.name( "W - Wref" );
+
+    params.error .width( 13 );
+    params.error2.width( 10 );
+    params.error3.width( 11 );
+    params.error4.width( 10 );
+    params.error5.width(  8 );
 
     if (! run)
         return;

--- a/test/test_gehrd.cc
+++ b/test/test_gehrd.cc
@@ -38,9 +38,6 @@ void test_gehrd_work( Params& params, bool run )
     params.gflops();
     params.ortho();
 
-    params.error.name( "A-UHU^H" );
-    params.ortho.name( "I-UU^H" );
-
     if (! run)
         return;
 

--- a/test/test_gehrd.cc
+++ b/test/test_gehrd.cc
@@ -38,8 +38,8 @@ void test_gehrd_work( Params& params, bool run )
     params.gflops();
     params.ortho();
 
-    params.error.name( "A - U H U^H\nerror" );
-    params.ortho.name( "I - U U^H\nerror" );
+    params.error.name( "A-UHU^H" );
+    params.ortho.name( "I-UU^H" );
 
     if (! run)
         return;

--- a/test/test_gesdd.cc
+++ b/test/test_gesdd.cc
@@ -36,7 +36,8 @@ void test_gesdd_work( Params& params, bool run )
     //params.gflops();
     params.ortho_U();
     params.ortho_V();
-    params.error_sigma();
+    params.error2();
+    params.error2.name( "Sigma" );
 
     if (! run)
         return;
@@ -125,10 +126,10 @@ void test_gesdd_work( Params& params, bool run )
         }
         errors[3] += rel_error( S_tst, S_ref );
     }
-    params.error()       = errors[0];
-    params.ortho_U()     = errors[1];
-    params.ortho_V()     = errors[2];
-    params.error_sigma() = errors[3];
+    params.error()   = errors[0];
+    params.ortho_U() = errors[1];
+    params.ortho_V() = errors[2];
+    params.error2()  = errors[3];
     params.okay() = (
         (jobu == lapack::Job::NoVec || errors[0] < tol) &&
         (jobu == lapack::Job::NoVec || errors[1] < tol) &&

--- a/test/test_gesvd.cc
+++ b/test/test_gesvd.cc
@@ -38,10 +38,10 @@ void test_gesvd_work( Params& params, bool run )
     //params.gflops();
     params.ortho_U();
     params.ortho_V();
-    params.error_sigma();
+    params.error2();
+    params.error2.name( "Sigma" );
     params.msg();
 
-    params.error.name( "A - USV^H\nerror" );
 
     if (! run)
         return;
@@ -154,10 +154,10 @@ void test_gesvd_work( Params& params, bool run )
         }
         errors[3] += rel_error( S_tst, S_ref );
     }
-    params.error()       = errors[0];
-    params.ortho_U()     = errors[1];
-    params.ortho_V()     = errors[2];
-    params.error_sigma() = errors[3];
+    params.error()   = errors[0];
+    params.ortho_U() = errors[1];
+    params.ortho_V() = errors[2];
+    params.error2()  = errors[3];
     params.okay() = (
         (jobu  == lapack::Job::NoVec || jobvt == lapack::Job::NoVec || errors[0] < tol) &&
         (jobu  == lapack::Job::NoVec || errors[1] < tol) &&

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -40,8 +40,8 @@ void test_symv_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "time (ms)" );
 
     if (! run)
         return;


### PR DESCRIPTION
See https://github.com/icl-utk-edu/blaspp/pull/13

TestSweeper allows headers to be 2 lines, which is nice for compact output, but harder to parse, e.g., by pandas. Use 1 line headers for ease of parsing. Also match SLATE's header names. Note it's fine to have space in a header. Columns are separated by 2 spaces, which is how we split data for pandas.