### PR TITLE
ci: sync with BLAS++

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 maker=$1
 device=$2
@@ -6,21 +6,28 @@ device=$2
 mydir=$(dirname $0)
 source ${mydir}/setup_env.sh
 
-section "======================================== Build"
-make -j8
+print "======================================== Build"
+make -j8 || exit 10
 
-section "======================================== Install"
-make -j8 install
+print "======================================== Install"
+make -j8 install || exit 11
 ls -R ${top}/install
 
-section "======================================== Verify build"
-ldd_result=$(ldd test/tester)
+print "======================================== Verify build"
+ldd_result=$(ldd test/tester) || exit 12
 echo "${ldd_result}"
 
 # Verify that tester linked with cublas or rocblas as intended.
 if [ "${device}" = "gpu_nvidia" ]; then
-    echo "${ldd_result}" | grep cublas || exit 1
+    echo "${ldd_result}" | grep cublas || exit 13
+
+elif [ "${device}" = "gpu_amd" ]; then
+    echo "${ldd_result}" | grep rocblas || exit 14
+
+else
+    # CPU-only not linked with cublas or rocblas.
+    echo "${ldd_result}" | grep -P "cublas|rocblas" && exit 15
 fi
-if [ "${device}" = "gpu_amd" ]; then
-    echo "${ldd_result}" | grep rocblas || exit 1
-fi
+
+print "======================================== Finished build"
+exit 0


### PR DESCRIPTION
Copies changes already applied in BLAS++.
- Renames `print` shell function.
- Handles errors explicitly rather than implicitly with `bash -e`.
- Sets `gpu_backend` to `none`, `cuda`, or `hip`, rather than relying on `auto` and what is in $path.