### PR TITLE
Add tgexc and tgsen to manipulate Schur form. Resolves #12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,10 +612,15 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
         lapackpp PRIVATE LAPACKPP_ID="${lapackpp_id}" )
 endif()
 
-# Use and export -std=c++11; don't allow -std=gnu++11 extensions.
-target_compile_features( lapackpp PUBLIC cxx_std_11 )
-set_target_properties( lapackpp PROPERTIES
-    CXX_EXTENSIONS OFF
+# Use and export -std=c++17.
+# CMake inexplicably allows gnu++17 or "decay" to c++11 or 14; prohibit those.
+target_compile_features(
+    lapackpp PUBLIC cxx_std_17
+)
+set_target_properties(
+    lapackpp PROPERTIES
+    CXX_STANDARD_REQUIRED true  # prohibit < c++17
+    CXX_EXTENSIONS false        # prohibit gnu++17
     WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,8 @@ add_library(
     src/tftri.cc
     src/tfttp.cc
     src/tfttr.cc
+    src/tgexc.cc
+    src/tgsen.cc
     src/tgsja.cc
     src/tgsyl.cc
     src/tpcon.cc

--- a/docs/doxygen/groups.dox
+++ b/docs/doxygen/groups.dox
@@ -89,6 +89,7 @@
         @defgroup ggev Generalized, AV = BV Lambda
         @defgroup gees Schur form, A = ZTZ^H
         @defgroup gges Generalized Schur form
+        @defgroup gges_internal Generalized Schur form, internal
         @defgroup geev_computational Computational routines
     @}
 

--- a/include/lapack/wrappers.hh
+++ b/include/lapack/wrappers.hh
@@ -9271,6 +9271,88 @@ int64_t tfttr(
     std::complex<double>* A, int64_t lda );
 
 // -----------------------------------------------------------------------------
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    float* A, int64_t lda,
+    float* B, int64_t ldb,
+    float* Q, int64_t ldq,
+    float* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst );
+
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    double* A, int64_t lda,
+    double* B, int64_t ldb,
+    double* Q, int64_t ldq,
+    double* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst );
+
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    std::complex<float>* A, int64_t lda,
+    std::complex<float>* B, int64_t ldb,
+    std::complex<float>* Q, int64_t ldq,
+    std::complex<float>* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst );
+
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    std::complex<double>* A, int64_t lda,
+    std::complex<double>* B, int64_t ldb,
+    std::complex<double>* Q, int64_t ldq,
+    std::complex<double>* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst );
+
+// -----------------------------------------------------------------------------
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    float* A, int64_t lda,
+    float* B, int64_t ldb,
+    std::complex<float>* alpha,
+    float* beta,
+    float* Q, int64_t ldq,
+    float* Z, int64_t ldz,
+    int64_t* sdim,
+    float* pl, float* pr, float* dif );
+
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    double* A, int64_t lda,
+    double* B, int64_t ldb,
+    std::complex<double>* alpha,
+    double* beta,
+    double* Q, int64_t ldq,
+    double* Z, int64_t ldz,
+    int64_t* sdim,
+    double* pl, double* pr, double* dif );
+
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    std::complex<float>* A, int64_t lda,
+    std::complex<float>* B, int64_t ldb,
+    std::complex<float>* alpha,
+    std::complex<float>* beta,
+    std::complex<float>* Q, int64_t ldq,
+    std::complex<float>* Z, int64_t ldz,
+    int64_t* sdim,
+    float* pl, float* pr, float* dif );
+
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    std::complex<double>* A, int64_t lda,
+    std::complex<double>* B, int64_t ldb,
+    std::complex<double>* alpha,
+    std::complex<double>* beta,
+    std::complex<double>* Q, int64_t ldq,
+    std::complex<double>* Z, int64_t ldz,
+    int64_t* sdim,
+    double* pl, double* pr, double* dif );
+
+// -----------------------------------------------------------------------------
 int64_t tgsja(
     lapack::Job jobu, lapack::Job jobv, lapack::Job jobq, int64_t m, int64_t p, int64_t n, int64_t k, int64_t l,
     float* A, int64_t lda,

--- a/src/tgexc.cc
+++ b/src/tgexc.cc
@@ -1,0 +1,330 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "lapack.hh"
+#include "lapack/fortran.h"
+
+#include <vector>
+
+namespace lapack {
+
+using blas::max;
+using blas::min;
+using blas::real;
+using blas::is_complex;
+
+//==============================================================================
+namespace internal {
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, float version.
+/// @ingroup gges_internal
+inline void tgexc(
+    lapack_int wantq, lapack_int wantz, lapack_int n,
+    float* A, lapack_int lda,
+    float* B, lapack_int ldb,
+    float* Q, lapack_int ldq,
+    float* Z, lapack_int ldz,
+    lapack_int* ifst, lapack_int* ilst,
+    float* work, lapack_int lwork, lapack_int* info )
+{
+    LAPACK_stgexc(
+        &wantq, &wantz, &n,
+        A, &lda,
+        B, &ldb,
+        Q, &ldq,
+        Z, &ldz, ifst, ilst, &work[0], &lwork, info );
+}
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, double version.
+/// @ingroup gges_internal
+inline void tgexc(
+    lapack_int wantq, lapack_int wantz, lapack_int n,
+    double* A, lapack_int lda,
+    double* B, lapack_int ldb,
+    double* Q, lapack_int ldq,
+    double* Z, lapack_int ldz,
+    lapack_int* ifst, lapack_int* ilst,
+    double* work, lapack_int lwork, lapack_int* info )
+{
+    LAPACK_dtgexc(
+        &wantq, &wantz, &n,
+        A, &lda,
+        B, &ldb,
+        Q, &ldq,
+        Z, &ldz, ifst, ilst, &work[0], &lwork, info );
+}
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, complex<float> version.
+/// @ingroup gges_internal
+inline void tgexc(
+    lapack_int wantq, lapack_int wantz, lapack_int n,
+    std::complex<float>* A, lapack_int lda,
+    std::complex<float>* B, lapack_int ldb,
+    std::complex<float>* Q, lapack_int ldq,
+    std::complex<float>* Z, lapack_int ldz,
+    lapack_int* ifst, lapack_int* ilst, lapack_int* info )
+{
+    // No workspace for complex.
+    LAPACK_ctgexc(
+        &wantq, &wantz, &n,
+        (lapack_complex_float*) A, &lda,
+        (lapack_complex_float*) B, &ldb,
+        (lapack_complex_float*) Q, &ldq,
+        (lapack_complex_float*) Z, &ldz, ifst, ilst, info );
+}
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, complex<double> version.
+/// @ingroup gges_internal
+inline void tgexc(
+    lapack_int wantq, lapack_int wantz, lapack_int n,
+    std::complex<double>* A, lapack_int lda,
+    std::complex<double>* B, lapack_int ldb,
+    std::complex<double>* Q, lapack_int ldq,
+    std::complex<double>* Z, lapack_int ldz,
+    lapack_int* ifst, lapack_int* ilst, lapack_int* info )
+{
+    // No workspace for complex.
+    LAPACK_ztgexc(
+        &wantq, &wantz, &n,
+        (lapack_complex_double*) A, &lda,
+        (lapack_complex_double*) B, &ldb,
+        (lapack_complex_double*) Q, &ldq,
+        (lapack_complex_double*) Z, &ldz, ifst, ilst, info );
+}
+
+}  // namespace internal
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// Mid-level templated wrapper checks and converts arguments,
+/// then calls low-level wrapper.
+/// @ingroup gges_internal
+///
+template <typename scalar_t>
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    scalar_t* A, int64_t lda,
+    scalar_t* B, int64_t ldb,
+    scalar_t* Q, int64_t ldq,
+    scalar_t* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst )
+{
+    // convert arguments
+    if (sizeof(int64_t) > sizeof(lapack_int)) {
+        lapack_error_if( std::abs(n)   > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
+    }
+    lapack_int wantq_ = (lapack_int) wantq;
+    lapack_int wantz_ = (lapack_int) wantz;
+    lapack_int n_ = (lapack_int) n;
+    lapack_int lda_ = (lapack_int) lda;
+    lapack_int ldb_ = (lapack_int) ldb;
+    lapack_int ldq_ = (lapack_int) ldq;
+    lapack_int ldz_ = (lapack_int) ldz;
+    lapack_int ifst_ = (lapack_int) *ifst;
+    lapack_int ilst_ = (lapack_int) *ilst;
+    lapack_int info_ = 0;
+
+    if constexpr (! is_complex<scalar_t>::value) {
+        // Real needs workspace.
+        // query for workspace size
+        scalar_t qry_work[1];
+        lapack_int ineg_one = -1;
+        internal::tgexc(
+            wantq_, wantz_, n_,
+            A, lda_, B, ldb_, Q, ldq_, Z, ldz_, &ifst_, &ilst_,
+            qry_work, ineg_one, &info_ );
+        if (info_ < 0) {
+            throw Error();
+        }
+        lapack_int lwork_ = real( qry_work[ 0 ] );
+
+        // allocate workspace
+        std::vector< scalar_t > work( lwork_ );
+
+        // call low-level wrapper
+        internal::tgexc(
+            wantq_, wantz_, n_,
+            A, lda_, B, ldb_, Q, ldq_, Z, ldz_, &ifst_, &ilst_,
+            &work[0], lwork_, &info_ );
+    }
+    else {
+        // call low-level wrapper
+        internal::tgexc(
+            wantq_, wantz_, n_,
+            A, lda_, B, ldb_, Q, ldq_, Z, ldz_, &ifst_, &ilst_, &info_ );
+    }
+    if (info_ < 0) {
+        throw Error();
+    }
+    *ifst = ifst_;
+    *ilst = ilst_;
+    return info_;
+}
+
+}  // namespace impl
+
+//==============================================================================
+/// Reorders the generalized Schur decomposition of a complex
+/// matrix pair (A,B), using an unitary equivalence transformation
+/// (A, B) := Q * (A, B) * Z^H, so that the diagonal block of (A, B) with
+/// row index ifst is moved to row ilst.
+///
+/// (A, B) must be in generalized Schur canonical form, that is, A and
+/// B are both upper triangular.
+///
+/// Optionally, the matrices Q and Z of generalized Schur vectors are
+/// updated.
+///
+///     Q(in) * A(in) * Z(in)^H = Q(out) * A(out) * Z(out)^H
+///     Q(in) * B(in) * Z(in)^H = Q(out) * B(out) * Z(out)^H
+///
+/// Overloaded versions are available for
+/// `float`, `double`, `std::complex<float>`, and `std::complex<double>`.
+///
+/// @param[in] wantq
+///     - true:  update the left transformation matrix Q;
+///     - false: do not update Q.
+///
+/// @param[in] wantz
+///     - true:  update the right transformation matrix Z;
+///     - false: do not update Z.
+///
+/// @param[in] n
+///     The order of the matrices A and B. n >= 0.
+///
+/// @param[in,out] A
+///     The n-by-n matrix A, stored in an lda-by-n array.
+///     On entry, the upper triangular matrix A in the pair (A, B).
+///     On exit, the updated matrix A.
+///
+/// @param[in] lda
+///     The leading dimension of the array A. lda >= max(1,n).
+///
+/// @param[in,out] B
+///     The n-by-n matrix B, stored in an ldb-by-n array.
+///     On entry, the upper triangular matrix B in the pair (A, B).
+///     On exit, the updated matrix B.
+///
+/// @param[in] ldb
+///     The leading dimension of the array B. ldb >= max(1,n).
+///
+/// @param[in,out] Q
+///     The n-by-n matrix Q, stored in an ldq-by-n array.
+///     On entry, if wantq = true, the unitary matrix Q.
+///     On exit, the updated matrix Q.
+///     If wantq = false, Q is not referenced.
+///
+/// @param[in] ldq
+///     The leading dimension of the array Q. ldq >= 1;
+///     If wantq = true, ldq >= n.
+///
+/// @param[in,out] Z
+///     The n-by-n matrix Z, stored in an ldz-by-n array.
+///     On entry, if wantz = true, the unitary matrix Z.
+///     On exit, the updated matrix Z.
+///     If wantz = false, Z is not referenced.
+///
+/// @param[in] ldz
+///     The leading dimension of the array Z. ldz >= 1;
+///     If wantz = true, ldz >= n.
+///
+/// @param[in,out] ifst
+/// @param[in,out] ilst
+///     Specify the reordering of the diagonal blocks of (A, B).
+///     The block with row index ifst is moved to row ilst, by a
+///     sequence of swapping between adjacent blocks.
+///     \n
+///     For the real version:
+///     On exit, if ifst pointed on entry to the second row of
+///     a 2-by-2 block, it is changed to point to the first row;
+///     ilst always points to the first row of the block in its
+///     final position (which may differ from its input value by
+///     +1 or -1). 1 <= ifst, ilst <= N.
+///     \n
+///     For the complex version:
+///     In LAPACK, ifst is only input [in], instead of input and output
+///     [in,out], but LAPACK++ uses a pointer to be consistent with the
+///     real routine.
+///
+/// @return
+/// * 0: Successful exit.
+/// * 1: The transformed matrix pair (A, B) would be too far
+///     from generalized Schur form; the problem is ill-
+///     conditioned. (A, B) may have been partially reordered,
+///     and ilst points to the first row of the current
+///     position of the block being moved.
+///
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, float version.
+/// @ingroup gges
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    float* A, int64_t lda,
+    float* B, int64_t ldb,
+    float* Q, int64_t ldq,
+    float* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst )
+{
+    return impl::tgexc(
+        wantq, wantz, n, A, lda, B, ldb, Q, ldq, Z, ldz, ifst, ilst );
+}
+
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, double version.
+/// @ingroup gges
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    double* A, int64_t lda,
+    double* B, int64_t ldb,
+    double* Q, int64_t ldq,
+    double* Z, int64_t ldz,
+    int64_t* ifst,
+    int64_t* ilst )
+{
+    return impl::tgexc(
+        wantq, wantz, n, A, lda, B, ldb, Q, ldq, Z, ldz, ifst, ilst );
+}
+
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, complex<float> version.
+/// @ingroup gges
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    std::complex<float>* A, int64_t lda,
+    std::complex<float>* B, int64_t ldb,
+    std::complex<float>* Q, int64_t ldq,
+    std::complex<float>* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst )
+{
+    return impl::tgexc(
+        wantq, wantz, n, A, lda, B, ldb, Q, ldq, Z, ldz, ifst, ilst );
+}
+
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, complex<double> version.
+/// @ingroup gges
+int64_t tgexc(
+    bool wantq, bool wantz, int64_t n,
+    std::complex<double>* A, int64_t lda,
+    std::complex<double>* B, int64_t ldb,
+    std::complex<double>* Q, int64_t ldq,
+    std::complex<double>* Z, int64_t ldz,
+    int64_t* ifst, int64_t* ilst )
+{
+    return impl::tgexc(
+        wantq, wantz, n, A, lda, B, ldb, Q, ldq, Z, ldz, ifst, ilst );
+}
+
+}  // namespace lapack

--- a/src/tgsen.cc
+++ b/src/tgsen.cc
@@ -1,0 +1,593 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "lapack.hh"
+#include "lapack/fortran.h"
+
+#include <vector>
+
+namespace lapack {
+
+using blas::real;
+using blas::is_complex;
+using blas::real_type;
+using blas::complex_type;
+
+//==============================================================================
+namespace internal {
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, float version.
+/// @ingroup gges_internal
+inline void tgsen(
+    lapack_int ijob, lapack_int wantq, lapack_int wantz,
+    lapack_logical const* select, lapack_int n,
+    float* A, lapack_int lda,
+    float* B, lapack_int ldb,
+    float* alphar, float* alphai,
+    float* beta,
+    float* Q, lapack_int ldq,
+    float* Z, lapack_int ldz,
+    lapack_int* sdim, float* pl, float* pr, float* dif,
+    float* work, lapack_int lwork,
+    lapack_int* iwork, lapack_int liwork,
+    lapack_int* info )
+{
+    LAPACK_stgsen(
+        &ijob, &wantq, &wantz, select, &n,
+        A, &lda, B, &ldb, alphar, alphai, beta,
+        Q, &ldq, Z, &ldz, sdim, pl, pr, dif,
+        work, &lwork, iwork, &liwork, info );
+}
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, double version.
+/// @ingroup gges_internal
+inline void tgsen(
+    lapack_int ijob, lapack_int wantq, lapack_int wantz,
+    lapack_logical const* select, lapack_int n,
+    double* A, lapack_int lda,
+    double* B, lapack_int ldb,
+    double* alphar, double* alphai,
+    double* beta,
+    double* Q, lapack_int ldq,
+    double* Z, lapack_int ldz,
+    lapack_int* sdim, double* pl, double* pr, double* dif,
+    double* work, lapack_int lwork,
+    lapack_int* iwork, lapack_int liwork,
+    lapack_int* info )
+{
+    LAPACK_dtgsen(
+        &ijob, &wantq, &wantz, select, &n,
+        A, &lda, B, &ldb, alphar, alphai, beta,
+        Q, &ldq, Z, &ldz, sdim, pl, pr, dif,
+        work, &lwork, iwork, &liwork, info );
+}
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, complex<float> version.
+/// @ingroup gges_internal
+inline void tgsen(
+    lapack_int ijob, lapack_int wantq, lapack_int wantz,
+    lapack_logical const* select, lapack_int n,
+    std::complex<float>* A, lapack_int lda,
+    std::complex<float>* B, lapack_int ldb,
+    std::complex<float>* alpha,
+    std::complex<float>* beta,
+    std::complex<float>* Q, lapack_int ldq,
+    std::complex<float>* Z, lapack_int ldz,
+    lapack_int* sdim, float* pl, float* pr, float* dif,
+    std::complex<float>* work, lapack_int lwork,
+    lapack_int* iwork, lapack_int liwork,
+    lapack_int* info )
+{
+    LAPACK_ctgsen(
+        &ijob, &wantq, &wantz,
+        select, &n,
+        (lapack_complex_float*) A, &lda,
+        (lapack_complex_float*) B, &ldb,
+        (lapack_complex_float*) alpha,
+        (lapack_complex_float*) beta,
+        (lapack_complex_float*) Q, &ldq,
+        (lapack_complex_float*) Z, &ldz, sdim, pl, pr, dif,
+        (lapack_complex_float*) work, &lwork,
+        iwork, &liwork, info );
+}
+
+//------------------------------------------------------------------------------
+/// Low-level overload wrapper calls Fortran, complex<double> version.
+/// @ingroup gges_internal
+inline void tgsen(
+    lapack_int ijob, lapack_int wantq, lapack_int wantz,
+    lapack_logical const* select, lapack_int n,
+    std::complex<double>* A, lapack_int lda,
+    std::complex<double>* B, lapack_int ldb,
+    std::complex<double>* alpha,
+    std::complex<double>* beta,
+    std::complex<double>* Q, lapack_int ldq,
+    std::complex<double>* Z, lapack_int ldz,
+    lapack_int* sdim,
+    double* pl, double* pr,
+    double* dif,
+    std::complex<double>* work, lapack_int lwork,
+    lapack_int* iwork, lapack_int liwork,
+    lapack_int* info )
+{
+    LAPACK_ztgsen(
+        &ijob, &wantq, &wantz, select, &n,
+        (lapack_complex_double*) A, &lda,
+        (lapack_complex_double*) B, &ldb,
+        (lapack_complex_double*) alpha,
+        (lapack_complex_double*) beta,
+        (lapack_complex_double*) Q, &ldq,
+        (lapack_complex_double*) Z, &ldz, sdim, pl, pr, dif,
+        (lapack_complex_double*) work, &lwork,
+        iwork, &liwork, info );
+}
+
+}  // namespace internal
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// Mid-level templated wrapper checks and converts arguments,
+/// then calls low-level wrapper.
+/// @ingroup gges_internal
+///
+template <typename scalar_t>
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    scalar_t* A, int64_t lda,
+    scalar_t* B, int64_t ldb,
+    complex_type<scalar_t>* alpha,
+    scalar_t* beta,
+    scalar_t* Q, int64_t ldq,
+    scalar_t* Z, int64_t ldz,
+    int64_t* sdim,
+    real_type<scalar_t>* pl, real_type<scalar_t>* pr,
+    real_type<scalar_t>* dif )
+{
+    // convert arguments
+    if (sizeof(int64_t) > sizeof(lapack_int)) {
+        lapack_error_if( std::abs(ijob) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(wantq) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(wantz) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
+        lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
+    }
+    lapack_int ijob_ = (lapack_int) ijob;
+    lapack_int wantq_ = (lapack_int) wantq;
+    lapack_int wantz_ = (lapack_int) wantz;
+    lapack_int n_ = (lapack_int) n;
+    lapack_int lda_ = (lapack_int) lda;
+    lapack_int ldb_ = (lapack_int) ldb;
+    lapack_int ldq_ = (lapack_int) ldq;
+    lapack_int ldz_ = (lapack_int) ldz;
+    lapack_int sdim_ = (lapack_int) *sdim;
+    lapack_int info_ = 0;
+
+    #if 0
+        // 32-bit copy
+        std::vector< lapack_logical > select_( &select[ 0 ], &select[ n ] );
+        lapack_logical const* select_ptr = &select_[ 0 ];
+    #else
+        lapack_logical const* select_ptr = select;
+    #endif
+
+    // For real, create vectors for split-complex representation.
+    // For complex, creates as dummy `int` type to be optimized away.
+    std::conditional_t< is_complex<scalar_t>::value, int, std::vector<scalar_t> >
+        alphar, alphai;
+    blas_unused( alphar );  // unused in complex
+    blas_unused( alphai );
+
+    // query for workspace size
+    scalar_t qry_work[ 1 ];
+    lapack_int qry_iwork[ 1 ];
+    lapack_int ineg_one = -1;
+    if constexpr (! is_complex<scalar_t>::value) {
+        // For real, use split-complex alpha.
+        alphar.resize( n );
+        alphai.resize( n );
+        internal::tgsen(
+            ijob_, wantq_, wantz_, select_ptr, n_,
+            A, lda_, B, ldb_, &alphar[ 0 ], &alphai[ 0 ], beta,
+            Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
+            qry_work, ineg_one, qry_iwork, ineg_one, &info_ );
+    }
+    else {
+        internal::tgsen(
+            ijob_, wantq_, wantz_, select_ptr, n_,
+            A, lda_, B, ldb_, alpha, beta,
+            Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
+            qry_work, ineg_one, qry_iwork, ineg_one, &info_ );
+    }
+    if (info_ < 0) {
+        throw Error();
+    }
+    // LAPACK <= 3.11 has query & documentation error in workspace size; add 1.
+    lapack_int lwork_  = real( qry_work[ 0 ] ) + 1;
+    lapack_int liwork_ = real( qry_iwork[ 0 ] );
+
+    // allocate workspace
+    std::vector< scalar_t > work( lwork_ );
+    std::vector< lapack_int > iwork( liwork_ );
+
+    // call low-level wrapper
+    if constexpr (! is_complex<scalar_t>::value) {
+        // For real, use split-complex alpha.
+        internal::tgsen(
+            ijob_, wantq_, wantz_, select_ptr, n_,
+            A, lda_, B, ldb_, &alphar[0], &alphai[0], beta,
+            Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
+            &work[0], lwork_, &iwork[0], liwork_, &info_ );
+        // Merge split-complex representation.
+        for (int64_t i = 0; i < n; ++i) {
+            alpha[ i ] = std::complex<scalar_t>( alphar[ i ], alphai[ i ] );
+        }
+    }
+    else {
+        internal::tgsen(
+            ijob_, wantq_, wantz_, select_ptr, n_,
+            A, lda_, B, ldb_, alpha, beta,
+            Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
+            &work[0], lwork_, &iwork[0], liwork_, &info_ );
+    }
+    if (info_ < 0) {
+        throw Error();
+    }
+    *sdim = sdim_;
+    return info_;
+}
+
+}  // namespace impl
+
+//==============================================================================
+/// Reorders the generalized Schur decomposition of a complex
+/// matrix pair (A, B) (in terms of an unitary equivalence trans-
+/// formation Q^H * (A, B) * Z), so that a selected cluster of eigenvalues
+/// appears in the leading diagonal blocks of the pair (A,B). The leading
+/// columns of Q and Z form unitary bases of the corresponding left and
+/// right eigenspaces (deflating subspaces). (A, B) must be in
+/// generalized Schur canonical form, that is, A and B are both upper
+/// triangular.
+///
+/// `tgsen` also computes the generalized eigenvalues
+///
+///     w(j) = alpha(j) / beta(j)
+///
+/// of the reordered matrix pair (A, B).
+///
+/// Optionally, the routine computes estimates of reciprocal condition
+/// numbers for eigenvalues and eigenspaces. These are
+///     Difu[ (A11, B11), (A22, B22) ]
+/// and
+///     Difl[ (A11, B11), (A22, B22) ],
+/// i.e. the separation(s)
+/// between the matrix pairs (A11, B11) and (A22, B22) that correspond to
+/// the selected cluster and the eigenvalues outside the cluster, resp.,
+/// and norms of "projections" onto left and right eigenspaces w.r.t.
+/// the selected cluster in the (1, 1)-block.
+///
+/// Overloaded versions are available for
+/// `float`, `double`, `std::complex<float>`, and `std::complex<double>`.
+///
+/// @param[in] ijob
+///     Whether condition numbers are required for the
+///     cluster of eigenvalues (pl and pr) or the deflating subspaces
+///     (Difu and Difl):
+///     * 0: Only reorder w.r.t. select. No extras.
+///     * 1: Reciprocal of norms of "projections" onto left and right
+///          eigenspaces w.r.t. the selected cluster (pl and pr).
+///     * 2: Upper bounds on Difu and Difl. F-norm-based estimate
+///          (dif(1:2)).
+///     * 3: Estimate of Difu and Difl. 1-norm-based estimate
+///          (dif(1:2)).
+///          About 5 times as expensive as ijob = 2.
+///     * 4: Compute pl, pr and dif (i.e. 0, 1 and 2 above):
+///          Economic version to get it all.
+///     * 5: Compute pl, pr and dif (i.e. 0, 1 and 3 above)
+///
+/// @param[in] wantq
+///     * true:  update the left transformation matrix Q;
+///     * false: do not update Q.
+///
+/// @param[in] wantz
+///     * true:  update the right transformation matrix Z;
+///     * false: do not update Z.
+///
+/// @param[in] select
+///     The vector select of length n.
+///     select specifies the eigenvalues in the selected cluster. To
+///     select an eigenvalue w(j), select(j) must be set to
+///     true.
+///
+/// @param[in] n
+///     The order of the matrices A and B. n >= 0.
+///
+/// @param[in,out] A
+///     The n-by-n matrix A, stored in an lda-by-n array.
+///     On entry, the upper triangular matrix A, in generalized
+///     Schur canonical form.
+///     On exit, A is overwritten by the reordered matrix A.
+///
+/// @param[in] lda
+///     The leading dimension of the array A. lda >= max(1,n).
+///
+/// @param[in,out] B
+///     The n-by-n matrix B, stored in an ldb-by-n array.
+///     On entry, the upper triangular matrix B, in generalized
+///     Schur canonical form.
+///     On exit, B is overwritten by the reordered matrix B.
+///
+/// @param[in] ldb
+///     The leading dimension of the array B. ldb >= max(1,n).
+///
+/// @param[out] alpha
+///     The vector alpha of length n.
+///
+/// @param[out] beta
+///     The vector beta of length n.
+///     \n
+///     The diagonal elements of A and B, respectively,
+///     when the pair (A, B) has been reduced to generalized Schur
+///     form. alpha(i) / beta(i) for i = 1, ..., n are the generalized
+///     eigenvalues.
+///
+/// @param[in,out] Q
+///     The n-by-n matrix Q, stored in an ldq-by-n array.
+///     On entry, if wantq = true, Q is an n-by-n matrix.
+///     On exit, Q has been postmultiplied by the left unitary
+///     transformation matrix which reorder (A, B); The leading sdim
+///     columns of Q form orthonormal bases for the specified pair of
+///     left eigenspaces (deflating subspaces).
+///     If wantq = false, Q is not referenced.
+///
+/// @param[in] ldq
+///     The leading dimension of the array Q. ldq >= 1.
+///     If wantq = true, ldq >= n.
+///
+/// @param[in,out] Z
+///     The n-by-n matrix Z, stored in an ldz-by-n array.
+///     On entry, if wantz = true, Z is an n-by-n matrix.
+///     On exit, Z has been postmultiplied by the left unitary
+///     transformation matrix which reorder (A, B); The leading sdim
+///     columns of Z form orthonormal bases for the specified pair of
+///     left eigenspaces (deflating subspaces).
+///     If wantz = false, Z is not referenced.
+///
+/// @param[in] ldz
+///     The leading dimension of the array Z. ldz >= 1.
+///     If wantz = true, ldz >= n.
+///
+/// @param[out] sdim
+///     The dimension of the specified pair of left and right
+///     eigenspaces (deflating subspaces) 0 <= sdim <= n.
+///     (Called `m` in LAPACK.)
+///
+/// @param[out] pl
+/// @param[out] pr
+///     * If ijob = 1, 4 or 5, then pl, pr are lower bounds on the
+///       reciprocal of the norm of "projections" onto left and right
+///       eigenspace with respect to the selected cluster.
+///       0 < pl, pr <= 1.
+///     * If sdim = 0 or sdim = n, then pl = pr = 1.
+///     * If ijob = 0, 2 or 3, then pl, pr are not referenced.
+///
+/// @param[out] dif
+///     The vector dif of length 2.
+///     * If ijob >= 2, dif(1:2) store the estimates of Difu and Difl.
+///     * If ijob = 2 or 4, dif(1:2) are F-norm-based upper bounds on
+///       Difu and Difl.
+///     * If ijob = 3 or 5, dif(1:2) are 1-norm-based
+///       estimates of Difu and Difl, computed using reversed
+///       communication with `lapack::lacn2`.
+///     * If sdim = 0 or n, dif(1:2) = F-norm([A, B]).
+///     * If ijob = 0 or 1, dif is not referenced.
+///
+/// @return
+/// * 0: Successful exit.
+/// * 1: Reordering of (A, B) failed because the transformed
+///     matrix pair (A, B) would be too far from generalized
+///     Schur form; the problem is very ill-conditioned.
+///     (A, B) may have been partially reordered.
+///     If requested, 0 is returned in dif(*), pl and pr.
+///
+// -----------------------------------------------------------------------------
+/// @par Further Details
+///
+/// `tgsen` first collects the selected eigenvalues by computing unitary
+/// U and W that move them to the top left corner of (A, B). In other
+/// words, the selected eigenvalues are the eigenvalues of (A11, B11) in
+///
+///     U^H (A, B) W = (A11 A12)  (B11 B12) n1
+///                    ( 0  A22), ( 0  B22) n2
+///                      n1  n2     n1  n2
+///
+/// where n = n1+n2 and U^H means the conjugate transpose of U. The first
+/// n1 columns of U and W span the specified pair of left and right
+/// eigenspaces (deflating subspaces) of (A, B).
+///
+/// If (A, B) has been obtained from the generalized real Schur
+/// decomposition of a matrix pair (C, D) = Q (A, B) Z^H, then the
+/// reordered generalized Schur form of (C, D) is given by
+///
+///     (C, D) = (QU) (U^H (A, B) W) (ZW)^H,
+///
+/// and the first n1 columns of QU and ZW span the corresponding
+/// deflating subspaces of (C, D) (Q and Z store QU and ZW, resp.).
+///
+/// Note that if the selected eigenvalue is sufficiently ill-conditioned,
+/// then its value may differ significantly from its value before
+/// reordering.
+///
+/// The reciprocal condition numbers of the left and right eigenspaces
+/// spanned by the first n1 columns of U and W (or QU and ZW) may
+/// be returned in dif(1:2), corresponding to Difu and Difl, resp.
+///
+/// The Difu and Difl are defined as:
+///
+///     Difu[(A11, B11), (A22, B22)] = sigma-min( Zu )
+/// and
+///     Difl[(A11, B11), (A22, B22)] = Difu[(A22, B22), (A11, B11)],
+///
+/// where sigma-min(Zu) is the smallest singular value of the
+/// (2 n1 n2)-by-(2 n1 n2) matrix
+///
+///     Zu = [ kron( In2, A11 )  -kron( A22^H, In1 ) ]
+///          [ kron( In2, B11 )  -kron( B22^H, In1 ) ].
+///
+/// Here, Inx is the identity matrix of size nx and A22^H is the
+/// conjugate transpose of A22. kron(X, Y) is the Kronecker product between
+/// the matrices X and Y.
+///
+/// When dif(2) is small, small changes in (A, B) can cause large changes
+/// in the deflating subspace. An approximate (asymptotic) bound on the
+/// maximum angular error in the computed deflating subspaces is
+///
+///     EPS * norm((A, B)) / dif(2),
+///
+/// where EPS is the machine precision.
+///
+/// The reciprocal norm of the projectors on the left and right
+/// eigenspaces associated with (A11, B11) may be returned in pl and pr.
+/// They are computed as follows. First we compute L and R so that
+/// P*(A, B)*Q is block diagonal, where
+///
+///     P = ( I -L ) n1           Q = ( I R ) n1
+///         ( 0  I ) n2    and        ( 0 I ) n2
+///           n1 n2                    n1 n2
+///
+/// and (L, R) is the solution to the generalized Sylvester equation
+///
+///     A11*R - L*A22 = -A12
+///     B11*R - L*B22 = -B12
+///
+/// Then pl = (F-norm(L)^2+1)^(-1/2) and pr = (F-norm(R)^2+1)^(-1/2).
+/// An approximate (asymptotic) bound on the average absolute error of
+/// the selected eigenvalues is
+///
+///     EPS * norm((A, B)) / pl.
+///
+/// There are also global error bounds which valid for perturbations up
+/// to a certain restriction:  A lower bound (x) on the smallest
+/// F-norm(E,F) for which an eigenvalue of (A11, B11) may move and
+/// coalesce with an eigenvalue of (A22, B22) under perturbation (E,F),
+/// (i.e. (A + E, B + F), is
+///
+///  x = min(Difu,Difl)/((1/(pl*pl)+1/(pr*pr))^(1/2)+2*max(1/pl,1/pr)).
+///
+/// An approximate bound on x can be computed from dif(1:2), pl and pr.
+///
+/// If y = ( F-norm(E,F) / x) <= 1, the angles between the perturbed
+/// (L', R') and unperturbed (L, R) left and right deflating subspaces
+/// associated with the selected cluster in the (1,1)-blocks can be
+/// bounded as
+///
+///  max-angle(L, L') <= arctan( y * pl / (1 - y * (1 - pl * pl)^(1/2))
+///  max-angle(R, R') <= arctan( y * pr / (1 - y * (1 - pr * pr)^(1/2))
+///
+/// See LAPACK User's Guide section 4.11 or the following references
+/// for more information.
+///
+/// Note that if the default method for computing the Frobenius-norm-
+/// based estimate dif is not wanted (see `lapack::latdf`), then the parameter
+/// IDIFJB (see below) should be changed from 3 to 4 (routine `lapack::latdf`
+/// (ijob = 2 will be used)). See `lapack::tgsyl` for more details.
+///
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, float version.
+/// @ingroup gges
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    float* A, int64_t lda,
+    float* B, int64_t ldb,
+    std::complex<float>* alpha,
+    float* beta,
+    float* Q, int64_t ldq,
+    float* Z, int64_t ldz,
+    int64_t* sdim,
+    float* pl, float* pr,
+    float* dif )
+{
+    return impl::tgsen(
+        ijob, wantq, wantz, select, n,
+        A, lda, B, ldb, alpha, beta,
+        Q, ldq, Z, ldz, sdim, pl, pr, dif );
+}
+
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, double version.
+/// @ingroup gges
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    double* A, int64_t lda,
+    double* B, int64_t ldb,
+    std::complex<double>* alpha,
+    double* beta,
+    double* Q, int64_t ldq,
+    double* Z, int64_t ldz,
+    int64_t* sdim,
+    double* pl, double* pr,
+    double* dif )
+{
+    return impl::tgsen(
+        ijob, wantq, wantz, select, n,
+        A, lda, B, ldb, alpha, beta,
+        Q, ldq, Z, ldz, sdim, pl, pr, dif );
+}
+
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, complex<float> version.
+/// @ingroup gges
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    std::complex<float>* A, int64_t lda,
+    std::complex<float>* B, int64_t ldb,
+    std::complex<float>* alpha,
+    std::complex<float>* beta,
+    std::complex<float>* Q, int64_t ldq,
+    std::complex<float>* Z, int64_t ldz,
+    int64_t* sdim,
+    float* pl, float* pr,
+    float* dif )
+{
+    return impl::tgsen(
+        ijob, wantq, wantz, select, n,
+        A, lda, B, ldb, alpha, beta,
+        Q, ldq, Z, ldz, sdim, pl, pr, dif );
+}
+
+//------------------------------------------------------------------------------
+/// High-level overloaded wrapper, complex<double> version.
+/// @ingroup gges
+int64_t tgsen(
+    int64_t ijob, bool wantq, bool wantz,
+    lapack_logical const* select, int64_t n,
+    std::complex<double>* A, int64_t lda,
+    std::complex<double>* B, int64_t ldb,
+    std::complex<double>* alpha,
+    std::complex<double>* beta,
+    std::complex<double>* Q, int64_t ldq,
+    std::complex<double>* Z, int64_t ldz,
+    int64_t* sdim,
+    double* pl, double* pr,
+    double* dif )
+{
+    return impl::tgsen(
+        ijob, wantq, wantz, select, n,
+        A, lda, B, ldb, alpha, beta,
+        Q, ldq, Z, ldz, sdim, pl, pr, dif );
+}
+
+}  // namespace lapack

--- a/src/tgsen.cc
+++ b/src/tgsen.cc
@@ -173,14 +173,6 @@ int64_t tgsen(
     lapack_int sdim_ = (lapack_int) *sdim;
     lapack_int info_ = 0;
 
-    #if 0
-        // 32-bit copy
-        std::vector< lapack_logical > select_( &select[ 0 ], &select[ n ] );
-        lapack_logical const* select_ptr = &select_[ 0 ];
-    #else
-        lapack_logical const* select_ptr = select;
-    #endif
-
     // For real, create vectors for split-complex representation.
     // For complex, creates as dummy `int` type to be optimized away.
     std::conditional_t< is_complex<scalar_t>::value, int, std::vector<scalar_t> >
@@ -197,14 +189,14 @@ int64_t tgsen(
         alphar.resize( n );
         alphai.resize( n );
         internal::tgsen(
-            ijob_, wantq_, wantz_, select_ptr, n_,
+            ijob_, wantq_, wantz_, select, n_,
             A, lda_, B, ldb_, &alphar[ 0 ], &alphai[ 0 ], beta,
             Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
             qry_work, ineg_one, qry_iwork, ineg_one, &info_ );
     }
     else {
         internal::tgsen(
-            ijob_, wantq_, wantz_, select_ptr, n_,
+            ijob_, wantq_, wantz_, select, n_,
             A, lda_, B, ldb_, alpha, beta,
             Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
             qry_work, ineg_one, qry_iwork, ineg_one, &info_ );
@@ -224,7 +216,7 @@ int64_t tgsen(
     if constexpr (! is_complex<scalar_t>::value) {
         // For real, use split-complex alpha.
         internal::tgsen(
-            ijob_, wantq_, wantz_, select_ptr, n_,
+            ijob_, wantq_, wantz_, select, n_,
             A, lda_, B, ldb_, &alphar[0], &alphai[0], beta,
             Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
             &work[0], lwork_, &iwork[0], liwork_, &info_ );
@@ -235,7 +227,7 @@ int64_t tgsen(
     }
     else {
         internal::tgsen(
-            ijob_, wantq_, wantz_, select_ptr, n_,
+            ijob_, wantq_, wantz_, select, n_,
             A, lda_, B, ldb_, alpha, beta,
             Q, ldq_, Z, ldz_, &sdim_, pl, pr, dif,
             &work[0], lwork_, &iwork[0], liwork_, &info_ );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -195,6 +195,8 @@ add_executable(
     test_sytrs.cc
     test_sytrs_aa.cc
     test_sytrs_rook.cc
+    test_tgexc.cc
+    test_tgsen.cc
     test_unghr.cc
     test_unglq.cc
     test_ungql.cc

--- a/test/print_matrix.hh
+++ b/test/print_matrix.hh
@@ -41,6 +41,7 @@ void print_matrix( int64_t m, int64_t n, T *A, int64_t lda,
 }
 
 // -----------------------------------------------------------------------------
+/// Overload for complex.
 template< typename T >
 void print_matrix( int64_t m, int64_t n, std::complex<T>* A, int64_t lda,
                    const char* format="%9.4f",
@@ -80,6 +81,18 @@ void print_matrix( int64_t m, int64_t n, std::complex<T>* A, int64_t lda,
 }
 
 // -----------------------------------------------------------------------------
+/// Overload with name.
+template< typename T >
+void print_matrix( const char* name,
+                   int64_t m, int64_t n, T *A, int64_t lda,
+                   const char* format="%9.4f",
+                   const char* format_int="%9.0f" )
+{
+    printf( "%s = ", name );
+    print_matrix( m, n, A, lda, format, format_int );
+}
+
+// -----------------------------------------------------------------------------
 template< typename T >
 void print_vector( int64_t n, T *x, int64_t incx,
                    const char* format="%9.4f",
@@ -106,6 +119,7 @@ void print_vector( int64_t n, T *x, int64_t incx,
 }
 
 // -----------------------------------------------------------------------------
+/// Overload for complex.
 template< typename T >
 void print_vector( int64_t n, std::complex<T>* x, int64_t incx,
                    const char* format="%9.4f",
@@ -137,6 +151,18 @@ void print_vector( int64_t n, std::complex<T>* x, int64_t incx,
         ix += incx;
     }
     printf( " ]';\n" );
+}
+
+// -----------------------------------------------------------------------------
+/// Overload with name.
+template< typename T >
+void print_vector( const char* name,
+                   int64_t n, T *x, int64_t incx,
+                   const char* format="%9.4f",
+                   const char* format_int="%9.0f" )
+{
+    printf( "%s = ", name );
+    print_vector( n, x, incx, format, format_int );
 }
 
 #endif        //  #ifndef PRINT_HH

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -113,6 +113,7 @@ group_opt.add_argument( '--equed',  action='store', help='default=%(default)s', 
 group_opt.add_argument( '--direction', action='store', help='default=%(default)s', default='f,b' )
 group_opt.add_argument( '--storev', action='store', help='default=%(default)s', default='c,r' )
 group_opt.add_argument( '--norm',   action='store', help='default=%(default)s', default='max,1,inf,fro' )
+group_opt.add_argument( '--ijob',   action='store', help='default=%(default)s', default='0:5' )
 group_opt.add_argument( '--jobz',   action='store', help='default=%(default)s', default='n,v' )
 group_opt.add_argument( '--jobvl',  action='store', help='default=%(default)s', default='n,v' )
 group_opt.add_argument( '--jobvr',  action='store', help='default=%(default)s', default='n,v' )
@@ -291,6 +292,7 @@ equed  = ' --equed '  + opts.equed  if (opts.equed)  else ''
 direction = ' --direction ' + opts.direction if (opts.direction) else ''
 storev = ' --storev ' + opts.storev if (opts.storev) else ''
 norm   = ' --norm '   + opts.norm   if (opts.norm)   else ''
+ijob   = ' --ijob '   + opts.ijob   if (opts.ijob)   else ''
 jobz   = ' --jobz '   + opts.jobz   if (opts.jobz)   else ''
 jobu   = ' --jobu '   + opts.jobu   if (opts.jobu)   else ''
 jobvt  = ' --jobvt '  + opts.jobvt  if (opts.jobvt)  else ''
@@ -651,6 +653,8 @@ if (opts.geev and opts.host):
     [ 'unmhr', gen + dtype_complex + align + mn + side + trans_nc ],  # complex does trans = N, C, not T
     #[ 'trevc', gen + dtype + align + n + side + howmany + select ],
     #[ 'geesx', gen + dtype + align + n + jobvs + sort + select + sense ],
+    [ 'tgexc', gen + dtype + align + n + jobvl + jobvr ],
+    [ 'tgsen', gen + dtype + align + n + jobvl + jobvr + ijob ],
     ]
 
 # svd

--- a/test/test.cc
+++ b/test/test.cc
@@ -372,6 +372,10 @@ std::vector< testsweeper::routines_t > routines = {
     //{ "trevc",              test_trevc,     Section::geev }, // TODO --howmany, need to setup a bool select array
     { "",                   nullptr,        Section::newline },
 
+    { "tgexc",              test_tgexc,     Section::geev },
+    { "tgsen",              test_tgsen,     Section::geev },
+    { "",                   nullptr,        Section::newline },
+
     // -----
     // driver: singular value decomposition
     { "gesvd",              test_gesvd,         Section::svd },
@@ -494,6 +498,7 @@ Params::Params():
     norm      ( "norm",    7,    ParamType::List, lapack::Norm::One,      lapack::char2norm, lapack::norm2char, lapack::norm2str, "norm: o=one, 2=two, i=inf, f=fro, m=max" ),
     direction ( "direction", 8,  ParamType::List, lapack::Direction::Forward, lapack::char2direction, lapack::direction2char, lapack::direction2str, "direction: f=forward, b=backward" ),
     storev    ( "storev", 10,    ParamType::List, lapack::StoreV::Columnwise, lapack::char2storev, lapack::storev2char, lapack::storev2str, "store vectors: c=columnwise, r=rowwise" ),
+    ijob      ( "ijob",    5,    ParamType::List,   0,   0,   5, "condition numbers to compute, 0 to 5; see tgsen docs" ),
     jobz      ( "jobz",    5,    ParamType::List, lapack::Job::NoVec, lapack::char2job, lapack::job2char, lapack::job2str, "eigenvectors: n=no vectors, v=vectors" ),
     jobvl     ( "jobvl",   5,    ParamType::List, lapack::Job::NoVec, lapack::char2job, lapack::job2char, lapack::job2str, "left eigenvectors: n=no vectors, v=vectors" ),
     jobvr     ( "jobvr",   5,    ParamType::List, lapack::Job::NoVec, lapack::char2job, lapack::job2char, lapack::job2str, "right eigenvectors: n=no vectors, v=vectors" ),
@@ -507,8 +512,7 @@ Params::Params():
                 lapack::char2matrixtype, lapack::matrixtype2char, lapack::matrixtype2str,
                 "matrix type: g=general, l=lower, u=upper, h=Hessenberg, z=band-general, b=band-lower, q=band-upper" ),
     factored  ( "factored",    11,    ParamType::List, lapack::Factored::NotFactored, lapack::char2factored, lapack::factored2char, lapack::factored2str, "f=Factored, n=NotFactored, e=Equilibrate" ),
-    equed  ( "equed",    9,    ParamType::List, lapack::Equed::None, lapack::char2equed, lapack::equed2char, lapack::equed2str, "n=None, r=Row, c=Col, b=Both, y=Yes" ),
-
+    equed     ( "equed",   9,    ParamType::List, lapack::Equed::None, lapack::char2equed, lapack::equed2char, lapack::equed2str, "n=None, r=Row, c=Col, b=Both, y=Yes" ),
 
     //          name,      w, p, type,            def,   min,     max, help
     dim       ( "dim",     6,    ParamType::List,          0, 1000000, "m by n by k dimensions" ),

--- a/test/test.hh
+++ b/test/test.hh
@@ -62,8 +62,9 @@ public:
     testsweeper::ParamEnum< lapack::Op >        transB;
     testsweeper::ParamEnum< lapack::Diag >      diag;
     testsweeper::ParamEnum< lapack::Norm >      norm;
-    testsweeper::ParamEnum< lapack::Direction >    direction;
+    testsweeper::ParamEnum< lapack::Direction > direction;
     testsweeper::ParamEnum< lapack::StoreV >    storev;
+    testsweeper::ParamInt                       ijob;   // tgsen
     testsweeper::ParamEnum< lapack::Job >       jobz;   // heev
     testsweeper::ParamEnum< lapack::Job >       jobvl;  // geev
     testsweeper::ParamEnum< lapack::Job >       jobvr;  // geev
@@ -393,6 +394,8 @@ void test_unghr ( Params& params, bool run );
 void test_unmhr ( Params& params, bool run );
 void test_hsein ( Params& params, bool run );
 void test_trevc ( Params& params, bool run );
+void test_tgexc ( Params& params, bool run );
+void test_tgsen ( Params& params, bool run );
 
 // generalized nonsymmetric eigenvalues
 void test_ggev  ( Params& params, bool run );

--- a/test/test_tgexc.cc
+++ b/test/test_tgexc.cc
@@ -1,0 +1,172 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "lapack.hh"
+#include "print_matrix.hh"
+#include "error.hh"
+#include "lapacke_wrappers.hh"
+
+#include <vector>
+
+//------------------------------------------------------------------------------
+template< typename scalar_t >
+void test_tgexc_work( Params& params, bool run )
+{
+    using real_t = blas::real_type< scalar_t >;
+    using complex_t = blas::complex_type< scalar_t >;
+    typedef long long lld;
+
+    // Constants
+    const real_t eps = std::numeric_limits<real_t>::epsilon();
+
+    // get & mark input values
+    lapack::Job jobvl = params.jobvl();
+    lapack::Job jobvr = params.jobvr();
+    bool wantq = jobvl == lapack::Job::Vec;
+    bool wantz = jobvr == lapack::Job::Vec;
+    int64_t n = params.dim.n();
+    int64_t align = params.align();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.ref_time();
+
+    if (! run)
+        return;
+
+    //---------- setup
+    int64_t lda = roundup( blas::max( 1, n ), align );
+    int64_t ldb = roundup( blas::max( 1, n ), align );
+    int64_t ldq = roundup( blas::max( 1, n ), align );
+    int64_t ldz = roundup( blas::max( 1, n ), align );
+    // Arbitrarily, move row 1/3n to 2/3n.
+    int64_t ifst_tst = blas::max( 1, n * 0.33 );
+    int64_t ilst_tst = blas::max( 1, n * 0.66 );
+    lapack_int ifst_ref = ifst_tst;
+    lapack_int ilst_ref = ilst_tst;
+    size_t size_A = (size_t) lda * n;
+    size_t size_B = (size_t) ldb * n;
+    size_t size_Q = (size_t) ldq * n;
+    size_t size_Z = (size_t) ldz * n;
+
+    std::vector< scalar_t > A_tst( size_A );
+    std::vector< scalar_t > B_tst( size_B );
+    std::vector< scalar_t > Q_tst( size_Q );
+    std::vector< scalar_t > Z_tst( size_Z );
+    std::vector< complex_t > alpha( n );
+    std::vector< scalar_t > beta( n );
+
+    int64_t idist = 1;
+    int64_t iseed[4] = { 0, 1, 2, 3 };
+    lapack::larnv( idist, iseed, A_tst.size(), &A_tst[0] );
+    lapack::larnv( idist, iseed, B_tst.size(), &B_tst[0] );
+    lapack::larnv( idist, iseed, Q_tst.size(), &Q_tst[0] );
+    lapack::larnv( idist, iseed, Z_tst.size(), &Z_tst[0] );
+
+    // Factor (A, B) matrices.
+    int64_t sdim_tst = 0;
+    int64_t info_tst = lapack::gges(
+        jobvl, jobvr, lapack::Sort::NotSorted, nullptr, n,
+        &A_tst[0], lda, &B_tst[0], ldb,
+        &sdim_tst, &alpha[0], &beta[0],
+        &Q_tst[0], ldq, &Z_tst[0], ldz );
+    if (info_tst != 0) {
+        fprintf( stderr, "lapack::gges returned error %lld\n", (lld) info_tst );
+        throw blas::Error();
+    }
+
+    std::vector< scalar_t > A_ref = A_tst;
+    std::vector< scalar_t > B_ref = B_tst;
+    std::vector< scalar_t > Q_ref = Q_tst;
+    std::vector< scalar_t > Z_ref = Z_tst;
+
+    //---------- run test
+    testsweeper::flush_cache( params.cache() );
+    double time = testsweeper::get_wtime();
+
+    info_tst = lapack::tgexc(
+        wantq, wantz, n,
+        &A_tst[0], lda, &B_tst[0], ldb,
+        &Q_tst[0], ldq, &Z_tst[0], ldz,
+        &ifst_tst, &ilst_tst );
+
+    time = testsweeper::get_wtime() - time;
+    if (info_tst != 0) {
+        fprintf( stderr, "lapack::tgexc returned error %lld\n", (lld) info_tst );
+    }
+
+    params.time() = time;
+
+    if (params.ref() == 'y' || params.check() == 'y') {
+        //---------- run reference
+        testsweeper::flush_cache( params.cache() );
+        time = testsweeper::get_wtime();
+
+        int64_t info_ref = LAPACKE_tgexc(
+            wantq, wantz, n,
+            &A_ref[0], lda, &B_ref[0], ldb,
+            &Q_ref[0], ldq, &Z_ref[0], ldz,
+            &ifst_ref, &ilst_ref );
+
+        time = testsweeper::get_wtime() - time;
+        if (info_ref != 0) {
+            fprintf( stderr, "LAPACKE_tgexc returned error %lld\n", (lld) info_ref );
+        }
+
+        params.ref_time() = time;
+
+        // LAPACKE has ifst, ilst as [in] instead of [in,out].
+        if (ifst_tst != ifst_ref || ilst_tst != ilst_ref) {
+            printf( "Note: ifst (%lld & %lld) or ilst (%lld & %lld) differ"
+                    " between (LAPACK++ & LAPACKE) due to LAPACKE issue.\n",
+                    llong( ifst_tst ), llong( ifst_ref ),
+                    llong( ilst_tst ), llong( ilst_ref ) );
+        }
+
+        //---------- check error compared to reference
+        real_t info_error  = (info_tst != 0 || info_ref != 0);
+        real_t A_error     = abs_error( A_tst, A_ref );
+        real_t B_error     = abs_error( B_tst, B_ref );
+        real_t Q_error     = abs_error( Q_tst, Q_ref );
+        real_t Z_error     = abs_error( Z_tst, Z_ref );
+        // real_t ifst_error = std::abs( ifst_tst - ifst_ref );  // see above
+        // real_t ilst_error = std::abs( ilst_tst - ilst_ref );  // see above
+        real_t error = info_error + A_error + B_error + Q_error + Z_error;
+        params.error() = error;
+        params.okay() = (error < eps);  // expect lapackpp ~= lapacke
+
+        if (verbose && error != 0) {
+            printf( "error %.3g = info %.3g + A %.3g + B %.3g + Q %.3g + Z %.3g\n",
+                    error, info_error, A_error, B_error, Q_error, Z_error );
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+void test_tgexc( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Integer:
+            throw std::exception();
+            break;
+
+        case testsweeper::DataType::Single:
+            test_tgexc_work< float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_tgexc_work< double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_tgexc_work< std::complex<float> >( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_tgexc_work< std::complex<double> >( params, run );
+            break;
+    }
+}

--- a/test/test_tgsen.cc
+++ b/test/test_tgsen.cc
@@ -1,0 +1,189 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "lapack.hh"
+#include "print_matrix.hh"
+#include "error.hh"
+#include "lapacke_wrappers.hh"
+
+#include <vector>
+
+//------------------------------------------------------------------------------
+template< typename scalar_t >
+void test_tgsen_work( Params& params, bool run )
+{
+    using real_t = blas::real_type< scalar_t >;
+    using complex_t = blas::complex_type< scalar_t >;
+    typedef long long lld;
+
+    // Constants
+    const real_t eps = std::numeric_limits<real_t>::epsilon();
+
+    // get & mark input values
+    int64_t ijob = params.ijob();
+    lapack::Job jobvl = params.jobvl();
+    lapack::Job jobvr = params.jobvr();
+    bool wantq = jobvl == lapack::Job::Vec;
+    bool wantz = jobvr == lapack::Job::Vec;
+    int64_t n = params.dim.n();
+    int64_t align = params.align();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.ref_time();
+
+    if (! run)
+        return;
+
+    //---------- setup
+    int64_t lda = roundup( blas::max( 1, n ), align );
+    int64_t ldb = roundup( blas::max( 1, n ), align );
+    int64_t ldq = roundup( blas::max( 1, n ), align );
+    int64_t ldz = roundup( blas::max( 1, n ), align );
+    int64_t    sdim_tst = -1;
+    lapack_int sdim_ref = -1;
+    real_t pl_tst = -1;
+    real_t pl_ref = -1;
+    real_t pr_tst = -1;
+    real_t pr_ref = -1;
+    size_t size_select = (size_t) n;
+    size_t size_alpha  = (size_t) n;
+    size_t size_beta   = (size_t) n;
+    size_t size_A = (size_t) lda * n;
+    size_t size_B = (size_t) ldb * n;
+    size_t size_Q = (size_t) ldq * n;
+    size_t size_Z = (size_t) ldz * n;
+    size_t size_dif = (size_t) 2;
+
+    std::vector< lapack_logical > select( size_select );
+    std::vector< scalar_t > A_tst( size_A );
+    std::vector< scalar_t > B_tst( size_B );
+    std::vector< complex_t > alpha_tst( size_alpha );
+    std::vector< scalar_t > beta_tst( size_beta );
+    std::vector< scalar_t > Q_tst( size_Q );
+    std::vector< scalar_t > Z_tst( size_Z );
+    std::vector< real_t > dif_tst( size_dif );
+    std::vector< real_t > dif_ref( size_dif );
+
+    int64_t idist = 1;
+    int64_t iseed[4] = { 0, 1, 2, 3 };
+    lapack::larnv( idist, iseed, A_tst.size(), &A_tst[0] );
+    lapack::larnv( idist, iseed, B_tst.size(), &B_tst[0] );
+    lapack::larnv( idist, iseed, Q_tst.size(), &Q_tst[0] );
+    lapack::larnv( idist, iseed, Z_tst.size(), &Z_tst[0] );
+
+    // Factor (A, B) matrices.
+    int64_t info_tst = lapack::gges(
+        jobvl, jobvr, lapack::Sort::NotSorted, nullptr, n,
+        &A_tst[0], lda, &B_tst[0], ldb,
+        &sdim_tst, &alpha_tst[0], &beta_tst[0],
+        &Q_tst[0], ldq, &Z_tst[0], ldz );
+    if (info_tst != 0) {
+        fprintf( stderr, "lapack::gges returned error %lld\n", (lld) info_tst );
+        throw blas::Error();
+    }
+
+    std::vector< complex_t > alpha_ref = alpha_tst;
+    std::vector< scalar_t > beta_ref  = beta_tst;
+    std::vector< scalar_t > A_ref = A_tst;
+    std::vector< scalar_t > B_ref = B_tst;
+    std::vector< scalar_t > Q_ref = Q_tst;
+    std::vector< scalar_t > Z_ref = Z_tst;
+
+    // Randomly select ~ 5% of eigenvalues to reorder.
+    for (int i = 0; i < n; ++i ) {
+        select[ i ] = (rand() / double(RAND_MAX)) < 0.05;
+    }
+
+    //---------- run test
+    testsweeper::flush_cache( params.cache() );
+    double time = testsweeper::get_wtime();
+
+    info_tst = lapack::tgsen(
+        ijob, wantq, wantz, &select[0], n,
+        &A_tst[0], lda, &B_tst[0], ldb, &alpha_tst[0], &beta_tst[0],
+        &Q_tst[0], ldq, &Z_tst[0], ldz,
+        &sdim_tst, &pl_tst, &pr_tst, &dif_tst[0] );
+
+    time = testsweeper::get_wtime() - time;
+    if (info_tst != 0) {
+        fprintf( stderr, "lapack::tgsen returned error %lld\n", (lld) info_tst );
+    }
+
+    params.time() = time;
+
+    if (params.ref() == 'y' || params.check() == 'y') {
+        //---------- run reference
+        testsweeper::flush_cache( params.cache() );
+        time = testsweeper::get_wtime();
+
+        int64_t info_ref = LAPACKE_tgsen(
+            ijob, wantq, wantz, &select[0], n,
+            &A_ref[0], lda, &B_ref[0], ldb, &alpha_ref[0], &beta_ref[0],
+            &Q_ref[0], ldq, &Z_ref[0], ldz,
+            &sdim_ref, &pl_ref, &pr_ref, &dif_ref[0] );
+
+        time = testsweeper::get_wtime() - time;
+        if (info_ref != 0) {
+            fprintf( stderr, "LAPACKE_tgsen returned error %lld\n", (lld) info_ref );
+        }
+
+        params.ref_time() = time;
+
+        //---------- check error compared to reference
+        real_t info_error  = (info_tst != 0 || info_ref != 0);
+        real_t A_error     = abs_error( A_tst, A_ref );
+        real_t B_error     = abs_error( B_tst, B_ref );
+        real_t Q_error     = abs_error( Q_tst, Q_ref );
+        real_t Z_error     = abs_error( Z_tst, Z_ref );
+        real_t alpha_error = abs_error( alpha_tst, alpha_ref );
+        real_t beta_error  = abs_error( beta_tst, beta_ref );
+        real_t sdim_error  = std::abs( sdim_tst - sdim_ref );
+        real_t pl_error    = std::abs( pl_tst - pl_ref );
+        real_t pr_error    = std::abs( pr_tst - pr_ref );
+        real_t dif_error   = abs_error( dif_tst, dif_ref );
+        real_t error = info_error + A_error + B_error + Q_error + Z_error
+                     + alpha_error + beta_error + sdim_error
+                     + pl_error + pr_error + dif_error;
+        params.error() = error;
+        params.okay() = (error < eps);  // expect lapackpp ~= lapacke
+
+        if (verbose && error != 0) {
+            printf( "error %.3g = info %.3g + A %.3g + B %.3g + Q %.3g + Z %.3g"
+                    " + alpha %.3g + beta %.3g + sdim %.3g"
+                    " + pl %.3g + pr %.3g + dif %.3g\n",
+                    error, info_error, A_error, B_error, Q_error, Z_error,
+                    alpha_error, beta_error, sdim_error,
+                    pl_error, pr_error, dif_error );
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+void test_tgsen( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Integer:
+            throw std::exception();
+            break;
+
+        case testsweeper::DataType::Single:
+            test_tgsen_work< float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_tgsen_work< double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_tgsen_work< std::complex<float> >( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_tgsen_work< std::complex<double> >( params, run );
+            break;
+    }
+}

--- a/tools/wrapper_gen.py
+++ b/tools/wrapper_gen.py
@@ -19,7 +19,8 @@ Example creating tester:
     /Users/mgates/Documents/lapack
 
     # Generate Fortran prototypes. Need to reformat nicely.
-    lapackpp> ./tools/header_gen.py {s,d,c,z}posv > gen/fortran.h
+    lapackpp> ./tools/header_gen.py {s,d,c,z}posv
+    generating gen/fortran.h
 
     # If necessary, add the routine to tools/first_version.py,
     # which is first version of LAPACK to include the routine.
@@ -1296,7 +1297,7 @@ def generate_docs( func ):
     # Further Details section
     d = func.details
     if (d):
-        txt += '// -----------------------------------------------------------------------------\n'
+        txt += '//------------------------------------------------------------------------------\n'
         txt += '/// @par Further Details\n'
         txt += parse_docs( func, d, variables, indent=4 )
     # end
@@ -1654,7 +1655,7 @@ def generate_tester( funcs ):
         # end
     # end
 
-    lapacke  = ('// -----------------------------------------------------------------------------\n'
+    lapacke  = ('//------------------------------------------------------------------------------\n'
              +  '// Simple overloaded wrappers around LAPACKE (assuming routines in LAPACKE).\n'
              +  '// These should go in test/lapacke_wrappers.hh.\n' )
     for func in funcs:
@@ -1724,7 +1725,7 @@ def generate_tester( funcs ):
     #----------
     # todo: only dispatch for precisions in funcs
     dispatch = ('''
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 void test_''' + func.name + '''( Params& params, bool run )
 {
 ''' + requires_if + '''\
@@ -1755,7 +1756,7 @@ void test_''' + func.name + '''( Params& params, bool run )
 
     txt = (requires_if2
         +  lapacke
-        +  '// -----------------------------------------------------------------------------\n'
+        +  '//------------------------------------------------------------------------------\n'
         +  'template< typename scalar_t >\n'
         +  'void test_' + func.name + '_work( Params& params, bool run )\n'
         +  '{\n'
@@ -1775,7 +1776,7 @@ void test_''' + func.name + '''( Params& params, bool run )
         +  tab + 'if (! run)\n'
         +  tab*2 + 'return;\n'
         +  '\n'
-        +  tab + '// ---------- setup\n'
+        +  tab + '//---------- setup\n'
         +  scalars2
         +  sizes
         +  '\n'
@@ -1784,7 +1785,7 @@ void test_''' + func.name + '''( Params& params, bool run )
         +  init
         +  copy
         +  '\n'
-        +  tab + '// ---------- run test\n'
+        +  tab + '//---------- run test\n'
         +  tab + 'testsweeper::flush_cache( params.cache() );\n'
         +  tab + 'double time = testsweeper::get_wtime();\n'
         +  tab + 'int64_t info_tst = lapack::' + func.name + '( ' + tst_args + ' );\n'
@@ -1798,7 +1799,7 @@ void test_''' + func.name + '''( Params& params, bool run )
         +  tab + 'params.gflops() = gflop / time;\n'
         +  '\n'
         +  tab + "if (params.ref() == 'y' || params.check() == 'y') {\n"
-        +  tab*2 + '// ---------- run reference\n'
+        +  tab*2 + '//---------- run reference\n'
         +  tab*2 + 'testsweeper::flush_cache( params.cache() );\n'
         +  tab*2 + 'time = testsweeper::get_wtime();\n'
         +  tab*2 + 'int64_t info_ref = LAPACKE_'  + func.name + '( ' + ref_args + ' );\n'
@@ -1810,7 +1811,7 @@ void test_''' + func.name + '''( Params& params, bool run )
         +  tab*2 + 'params.ref_time() = time;\n'
         +  tab*2 + 'params.ref_gflops() = gflop / time;\n'
         +  '\n'
-        +  tab*2 + '// ---------- check error compared to reference\n'
+        +  tab*2 + '//---------- check error compared to reference\n'
         +  tab*2 + 'real_t error = 0;\n'
         +  tab*2 + 'if (info_tst != info_ref) {\n'
         +  tab*2 + '    error = 1;\n'


### PR DESCRIPTION
Functions to manipulate Generalized Schur decomposition. Resolves #12.
- tgexc reorders the generalized Schur decomposition for 2 rows
- tgsen reorders the generalized Schur decomposition for selected cluster of eigenvalues

One question in the API was what to do for the `select` vector. It could be `bool*`, but in the tester, in C++ you can't take the address of an element of `std::vector<bool>` because `std::vector` is overloaded to pack each bool into 1 bit. It could be `int64_t*`, as other arguments are, but then we have to malloc & copy into `lapack_logical` array (which is often 32-bit int). Instead, I chose to pass in an `lapack_logical` array. This decision potentially affects `stemr`, `trevc[3]`, and `trsen`, which also have `bool*` arrays.

3 LAPACK(E) bugs were discovered in the process:
- Reference-LAPACK/lapack#771
- Reference-LAPACK/lapack#772 (closed)
- Reference-LAPACK/lapack#774