### PR TITLE
Add test_orhr_col. Disable LAPACKE call.

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -11,13 +11,6 @@ fi
 mydir=$(dirname $0)
 source ${mydir}/setup_env.sh
 
-print "======================================== Verify dependencies"
-quiet module list
-quiet which g++
-quiet g++ --version
-
-echo "MKLROOT=${MKLROOT}"
-
 print "======================================== Environment"
 env
 

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -35,7 +35,14 @@ shopt -s expand_aliases
 
 print "======================================== Load compiler"
 quiet module load gcc@7.3.0
+quiet which g++
+g++ --version
+
 quiet module load intel-mkl
+echo "MKLROOT=${MKLROOT}"
+
+quiet module load pkgconf
+quiet which pkg-config
 
 # CMake will find CUDA in /usr/local/cuda, so need to explicitly set
 # gpu_backend.
@@ -70,3 +77,5 @@ if [ "${maker}" = "cmake" ]; then
     cmake --version
     cd build
 fi
+
+quiet module list

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -30,7 +30,10 @@ if [ "${maker}" = "make" ]; then
 fi
 if [ "${maker}" = "cmake" ]; then
     rm -rf build && mkdir build && cd build
-    cmake "-DCMAKE_PREFIX_PATH=${top}/install/lib64/blaspp;${top}/install/lib64/lapackpp" ..
+    # On some systems, CMake GNUInstallDirs uses lib, on others lib64.
+    lib="${top}/install/lib/blaspp;${top}/install/lib/lapackpp"
+    lib64="${top}/install/lib64/blaspp;${top}/install/lib64/lapackpp"
+    cmake "-DCMAKE_PREFIX_PATH=${lib};${lib64}" ..
 fi
 
 make

--- a/src/cuda/cuda_potrf.cc
+++ b/src/cuda/cuda_potrf.cc
@@ -12,13 +12,14 @@
 
 //==============================================================================
 // todo: put into BLAS++ header somewhere.
+// changed from blas::device to blas::internal in 5ca8ad35 2022-11-28
 
 namespace blas {
-namespace device {
+namespace internal {
 
 cublasFillMode_t uplo2cublas( blas::Uplo uplo );
 
-} // namespace device
+} // namespace internal
 } // namespace blas
 
 //==============================================================================
@@ -118,7 +119,7 @@ void potrf_work_size_bytes(
     lapack::Queue& queue )
 {
     auto solver = queue.solver();
-    auto uplo_ = blas::device::uplo2cublas( uplo );
+    auto uplo_ = blas::internal::uplo2cublas( uplo );
 
     // query for workspace size
     #if CUSOLVER_VERSION >= 11000
@@ -148,7 +149,7 @@ void potrf(
 {
     // todo: check for overflow
     auto solver = queue.solver();
-    auto uplo_ = blas::device::uplo2cublas( uplo );
+    auto uplo_ = blas::internal::uplo2cublas( uplo );
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );

--- a/src/rocm/rocm_potrf.cc
+++ b/src/rocm/rocm_potrf.cc
@@ -11,13 +11,14 @@
 
 //==============================================================================
 // todo: put into BLAS++ header somewhere.
+// changed from blas::device to blas::internal in 5ca8ad35 2022-11-28
 
 namespace blas {
-namespace device {
+namespace internal {
 
 rocblas_fill uplo2rocblas(blas::Uplo uplo);
 
-} // namespace device
+} // namespace internal
 } // namespace blas
 
 //==============================================================================
@@ -73,7 +74,7 @@ void potrf(
 {
     // todo: check for overflow
     auto solver = queue.handle();
-    auto uplo_ = blas::device::uplo2rocblas( uplo );
+    auto uplo_ = blas::internal::uplo2rocblas( uplo );
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -203,8 +203,8 @@ add_executable(
     test_ungqr.cc
     test_ungrq.cc
     test_ungtr.cc
+    test_unhr_col.cc    test_orhr_col.cc
     test_unmhr.cc
-    test_unhr_col.cc
     test_unmtr.cc
     test_upgtr.cc
     test_upmtr.cc

--- a/test/lapacke_wrappers.hh
+++ b/test/lapacke_wrappers.hh
@@ -9949,6 +9949,85 @@ inline lapack_int LAPACKE_ungtr(
 }
 
 // -----------------------------------------------------------------------------
+// LAPACKE_*unhr_col only in Intel MKL, not yet Netlib LAPACK as of 3.10.
+#if LAPACK_VERSION >= 30900 && defined( LAPACK_HAVE_MKL ) // >= 3.9.0
+
+inline lapack_int LAPACKE_orhr_col(
+    lapack_int m, lapack_int n, lapack_int nb,
+    float* A, lapack_int lda,
+    float* T, lapack_int ldt,
+    float* D )
+{
+    return LAPACKE_sorhr_col(
+        LAPACK_COL_MAJOR, m, n, nb,
+        A, lda,
+        T, ldt,
+        D );
+}
+
+inline lapack_int LAPACKE_orhr_col(
+    lapack_int m, lapack_int n, lapack_int nb,
+    double* A, lapack_int lda,
+    double* T, lapack_int ldt,
+    double* D )
+{
+    return LAPACKE_dorhr_col(
+        LAPACK_COL_MAJOR, m, n, nb,
+        A, lda,
+        T, ldt,
+        D );
+}
+
+// In real, unhr is an alias for orhr.
+inline lapack_int LAPACKE_unhr_col(
+    lapack_int m, lapack_int n, lapack_int nb,
+    float* A, lapack_int lda,
+    float* T, lapack_int ldt,
+    float* D )
+{
+    return LAPACKE_orhr_col( m, n, nb, A, lda, T, ldt, D );
+}
+
+// In real, unhr is an alias for orhr.
+inline lapack_int LAPACKE_unhr_col(
+    lapack_int m, lapack_int n, lapack_int nb,
+    double* A, lapack_int lda,
+    double* T, lapack_int ldt,
+    double* D )
+{
+    return LAPACKE_orhr_col( m, n, nb, A, lda, T, ldt, D );
+}
+
+inline lapack_int LAPACKE_unhr_col(
+    lapack_int m, lapack_int n, lapack_int nb,
+    std::complex<float>* A, lapack_int lda,
+    std::complex<float>* T, lapack_int ldt,
+    std::complex<float>* D )
+{
+    return LAPACKE_cunhr_col(
+        LAPACK_COL_MAJOR, m, n, nb,
+        (lapack_complex_float*) A, lda,
+        (lapack_complex_float*) T, ldt,
+        (lapack_complex_float*) D );
+}
+
+inline lapack_int LAPACKE_unhr_col(
+    lapack_int m, lapack_int n, lapack_int nb,
+    std::complex<double>* A, lapack_int lda,
+    std::complex<double>* T, lapack_int ldt,
+    std::complex<double>* D )
+{
+    return LAPACKE_zunhr_col(
+        LAPACK_COL_MAJOR, m, n, nb,
+        (lapack_complex_double*) A, lda,
+        (lapack_complex_double*) T, ldt,
+        (lapack_complex_double*) D );
+}
+
+#endif  // 3.9.0 and LAPACK_HAVE_MKL
+
+
+// -----------------------------------------------------------------------------
 inline lapack_int LAPACKE_unmhr(
     char side, char trans, lapack_int m, lapack_int n, lapack_int ilo, lapack_int ihi,
     float* A, lapack_int lda,

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -522,7 +522,9 @@ if (opts.qr and opts.host):
     [ 'ungqr', gen + dtype + align + mn ],  # m >= n
     #[ 'unmqr', gen + dtype_real    + align + mnk + side + trans    ],  # real does trans = N, T, C
     #[ 'unmqr', gen + dtype_complex + align + mnk + side + trans_nc ],  # complex does trans = N, C, not T
-    [ 'unhr_col', gen + dtype + align + n + tall ],
+
+    [ 'orhr_col', gen + dtype_real + align + n + tall ],
+    [ 'unhr_col', gen + dtype      + align + n + tall ],
 
     # Triangle-pentagon
     [ 'tpqrt',  gen + dtype + align + mn + l + nb ],

--- a/test/test.cc
+++ b/test/test.cc
@@ -251,7 +251,6 @@ std::vector< testsweeper::routines_t > routines = {
     { "gelqf",              test_gelqf,     Section::qr }, // tested numerically
     { "geqlf",              test_geqlf,     Section::qr }, // tested numerically
     { "gerqf",              test_gerqf,     Section::qr }, // tested numerically; R, Q are full sizeof(A), could be smaller
-    { "unhr_col",           test_unhr_col,  Section::qr },
     { "",                   nullptr,        Section::newline },
 
     { "ggqrf",              test_ggqrf,     Section::qr }, // tested via LAPACKE using gcc/MKL, TODO for now use p=param.k
@@ -266,6 +265,10 @@ std::vector< testsweeper::routines_t > routines = {
     { "unglq",              test_unglq,     Section::qr }, // tested numerically based on lapack; R, Q full; m<=n, k<=m
     { "ungql",              test_ungql,     Section::qr }, // tested numerically based on lapack; R, Q full sizes
     { "ungrq",              test_ungrq,     Section::qr }, // tested numerically based on lapack; R, Q full sizes
+    { "",                   nullptr,        Section::newline },
+
+    { "orhr_col",           test_orhr_col,  Section::qr },
+    { "unhr_col",           test_unhr_col,  Section::qr },
     { "",                   nullptr,        Section::newline },
 
     //{ "unmqr",              test_unmqr,     Section::qr }, // TODO segfaults

--- a/test/test.hh
+++ b/test/test.hh
@@ -318,11 +318,13 @@ void test_unglq ( Params& params, bool run );
 void test_ungql ( Params& params, bool run );
 void test_ungrq ( Params& params, bool run );
 
+void test_orhr_col( Params& params, bool run );
+void test_unhr_col( Params& params, bool run );
+
 void test_unmqr ( Params& params, bool run );
 void test_unmlq ( Params& params, bool run );
 void test_unmql ( Params& params, bool run );
 void test_unmrq ( Params& params, bool run );
-void test_unhr_col( Params& params, bool run );
 
 // triangle-pentagon QR, LQ
 void test_tpqrt ( Params& params, bool run );

--- a/test/test_orhr_col.cc
+++ b/test/test_orhr_col.cc
@@ -15,7 +15,7 @@
 
 // -----------------------------------------------------------------------------
 template< typename scalar_t >
-void test_unhr_col_work( Params& params, bool run )
+void test_orhr_col_work( Params& params, bool run )
 {
     using real_t = blas::real_type< scalar_t >;
     typedef long long lld;
@@ -54,10 +54,10 @@ void test_unhr_col_work( Params& params, bool run )
     // ---------- run test
     testsweeper::flush_cache( params.cache() );
     double time = testsweeper::get_wtime();
-    int64_t info_tst = lapack::unhr_col( m, n, nb, &A_tst[0], lda, &T_tst[0], ldt, &D_tst[0] );
+    int64_t info_tst = lapack::orhr_col( m, n, nb, &A_tst[0], lda, &T_tst[0], ldt, &D_tst[0] );
     time = testsweeper::get_wtime() - time;
     if (info_tst != 0) {
-        fprintf( stderr, "lapack::unhr_col returned error %lld\n", (lld) info_tst );
+        fprintf( stderr, "lapack::orhr_col returned error %lld\n", (lld) info_tst );
     }
 
     params.time() = time;
@@ -67,10 +67,10 @@ void test_unhr_col_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_unhr_col( m, n, nb, &A_ref[0], lda, &T_ref[0], ldt, &D_ref[0] );
+        int64_t info_ref = LAPACKE_orhr_col( m, n, nb, &A_ref[0], lda, &T_ref[0], ldt, &D_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
-            fprintf( stderr, "LAPACKE_unhr_col returned error %lld\n", (lld) info_ref );
+            fprintf( stderr, "LAPACKE_orhr_col returned error %lld\n", (lld) info_ref );
         }
 
         params.ref_time() = time;
@@ -92,24 +92,16 @@ void test_unhr_col_work( Params& params, bool run )
 #endif  // LAPACK >= 3.9.0
 
 // -----------------------------------------------------------------------------
-void test_unhr_col( Params& params, bool run )
+void test_orhr_col( Params& params, bool run )
 {
 #if LAPACK_VERSION >= 30900  // >= 3.9.0
     switch (params.datatype()) {
         case testsweeper::DataType::Single:
-            test_unhr_col_work< float >( params, run );
+            test_orhr_col_work< float >( params, run );
             break;
 
         case testsweeper::DataType::Double:
-            test_unhr_col_work< double >( params, run );
-            break;
-
-        case testsweeper::DataType::SingleComplex:
-            test_unhr_col_work< std::complex<float> >( params, run );
-            break;
-
-        case testsweeper::DataType::DoubleComplex:
-            test_unhr_col_work< std::complex<double> >( params, run );
+            test_orhr_col_work< double >( params, run );
             break;
 
         default:
@@ -117,7 +109,7 @@ void test_unhr_col( Params& params, bool run )
             break;
     }
 #else
-    fprintf( stderr, "unhr_col requires LAPACK >= 3.9.0\n\n" );
+    fprintf( stderr, "orhr_col requires LAPACK >= 3.9.0\n\n" );
     exit(0);
 #endif
 }

--- a/test/test_orhr_col.cc
+++ b/test/test_orhr_col.cc
@@ -86,6 +86,9 @@ void test_orhr_col_work( Params& params, bool run )
         params.error() = error;
         params.okay() = (error == 0);  // expect lapackpp == lapacke
     }
+    #else
+        // LAPACKE_unhr_col not yet in LAPACK
+        params.msg() = "check requires Intel MKL, as of LAPACK 3.11";
     #endif  // LAPACK_HAVE_MKL
 }
 

--- a/test/test_unhr_col.cc
+++ b/test/test_unhr_col.cc
@@ -86,6 +86,9 @@ void test_unhr_col_work( Params& params, bool run )
         params.error() = error;
         params.okay() = (error == 0);  // expect lapackpp == lapacke
     }
+    #else
+        // LAPACKE_unhr_col not yet in LAPACK
+        params.msg() = "check requires Intel MKL, as of LAPACK 3.11";
     #endif  // LAPACK_HAVE_MKL
 }
 


### PR DESCRIPTION
Test for orhr_col (real) was missing. There are minimal differences from complex:
```
meld test_unhr_col.cc test_orhr_col.cc
```

As of LAPACK 3.11, LAPACKE is missing LAPACKE_*{or,un}hr_col. It was added in Intel MKL, so enable LAPACKE test with MKL. See Reference-LAPACK/lapack#726.