### PR TITLE
Lapackpp onemkl

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -71,7 +71,7 @@ endif
 #-------------------------------------------------------------------------------
 # Files
 
-lib_src  = $(wildcard src/*.cc src/cuda/*.cc src/rocm/*.cc src/stub/*.cc)
+lib_src  = $(wildcard src/*.cc src/cuda/*.cc src/rocm/*.cc src/onemkl/*.cc src/stub/*.cc)
 lib_obj  = $(addsuffix .o, $(basename $(lib_src)))
 dep     += $(addsuffix .d, $(basename $(lib_src)))
 

--- a/config/config.py
+++ b/config/config.py
@@ -671,7 +671,8 @@ def onemkl_library():
         inc = '-I' + root + '/linux/include ' \
             + '-I' + root + '/linux/include/sycl '
     env = {'LIBS': libs,
-           'CXXFLAGS': inc + define('HAVE_ONEMKL') + ' -Wno-deprecated-declarations'}
+           'CXXFLAGS': inc + define('HAVE_ONEMKL')
+           + ' -fsycl -Wno-deprecated-declarations -fhonor-nan-compares'}
     (rc, out, err) = compile_exe( 'config/onemkl.cc', env )
     print_result( libs, rc )
     if (rc == 0):
@@ -714,16 +715,15 @@ def gpu_blas():
         print_msg( font.red( 'skipping HIP/ROCm search' ) )
 
     #----- oneMKL
-    # Disable oneMKL until BLAS++ oneMKL support is finished.
-    #if (not gpu_blas_found and test_onemkl):
-    #    try:
-    #        onemkl_library()
-    #        gpu_blas_found = True
-    #    except Error as ex:
-    #        if (gpu_backend == 'onemkl'):
-    #            raise ex  # fatal
-    #else:
-    #    print_msg( font.red( 'skipping oneMKL search' ) )
+    if (not gpu_blas_found and test_onemkl):
+        try:
+            onemkl_library()
+            gpu_blas_found = True
+        except Error as ex:
+            if (gpu_backend == 'onemkl'):
+                raise ex  # fatal
+    else:
+        print_msg( font.red( 'skipping oneMKL search' ) )
 
     if (not gpu_blas_found):
         print_warn( 'No GPU BLAS library found' )

--- a/config/onemkl.cc
+++ b/config/onemkl.cc
@@ -3,8 +3,8 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <CL/sycl/detail/cl.h>
-#include <CL/sycl.hpp>
+#include <sycl/detail/cl.h>
+#include <sycl.hpp>
 #include <oneapi/mkl.hpp>
 
 #include <stdexcept>
@@ -23,7 +23,7 @@ int main()
     double D[] = { 40, 61, 21, 28 };
 
     // enumerate devices
-    std::vector< cl::sycl::device > devices;
+    std::vector< sycl::device > devices;
     auto platforms = sycl::platform::get_platforms();
     for (auto& platform : platforms) {
         auto all_devices = platform.get_devices();
@@ -41,9 +41,9 @@ int main()
     sycl::queue queue( devices[0] );
 
     double *dA, *dB, *dC;
-    dA = (double*) cl::sycl::malloc_shared( n*n*sizeof(double), queue );
-    dB = (double*) cl::sycl::malloc_shared( n*n*sizeof(double), queue );
-    dC = (double*) cl::sycl::malloc_shared( n*n*sizeof(double), queue );
+    dA = (double*) sycl::malloc_shared( n*n*sizeof(double), queue );
+    dB = (double*) sycl::malloc_shared( n*n*sizeof(double), queue );
+    dC = (double*) sycl::malloc_shared( n*n*sizeof(double), queue );
 
     // dA = A, dB = B, dC = c
     queue.memcpy( dA, A, n*n*sizeof(double) );

--- a/src/onemkl/onemkl_common.hh
+++ b/src/onemkl/onemkl_common.hh
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef LAPACK_ONEMKL_COMMON_H
+#define LAPACK_ONEMKL_COMMON_H
+
+#include "lapack/device.hh"
+
+#include <sycl/detail/cl.h>  // For CL version
+#include <sycl.hpp>
+
+#define MKL_Complex8  lapack_complex_float
+#define MKL_Complex16 lapack_complex_double
+
+#include <oneapi/mkl.hpp>
+
+#endif // LAPACK_ONEMKL_COMMON_H

--- a/src/onemkl/onemkl_geqrf.cc
+++ b/src/onemkl/onemkl_geqrf.cc
@@ -22,7 +22,7 @@ void geqrf_work_size_bytes(
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue )
 {
-    auto solver = queue.handle();
+    auto solver = queue.stream();
 
     int64_t lwork = 0;
     blas_dev_call(
@@ -44,7 +44,7 @@ void geqrf(
     void* host_work, size_t host_work_size,
     device_info_int* dev_info, lapack::Queue& queue )
 {
-    auto solver = queue.handle();
+    auto solver = queue.stream();
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );

--- a/src/onemkl/onemkl_geqrf.cc
+++ b/src/onemkl/onemkl_geqrf.cc
@@ -1,0 +1,126 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "lapack/defines.h"
+
+#if defined(LAPACK_HAVE_ONEMKL)
+
+#include "onemkl_common.hh"
+
+//==============================================================================
+namespace lapack {
+
+//------------------------------------------------------------------------------
+// Wrapper around workspace query.
+// dA is only for templating scalar_t; it isn't referenced.
+template <typename scalar_t>
+void geqrf_work_size_bytes(
+    int64_t m, int64_t n,
+    scalar_t* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    auto solver = queue.handle();
+
+    int64_t lwork = 0;
+    blas_dev_call(
+        lwork = oneapi::mkl::lapack::geqrf_scratchpad_size<scalar_t>(
+            solver, m, n, ldda ));
+    *dev_work_size = lwork * sizeof(scalar_t);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Wrapper around oneMKL.
+// This is async. Once finished, the return info is in dev_info on the device.
+// In oneMKL, there is no info. todo: set it to 0?
+template <typename scalar_t>
+void geqrf(
+    int64_t m, int64_t n,
+    scalar_t* dA, int64_t ldda, scalar_t* dtau,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    auto solver = queue.handle();
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    int64_t lwork = dev_work_size / sizeof(scalar_t);
+    blas_dev_call(
+        oneapi::mkl::lapack::geqrf(
+            solver, m, n, dA, ldda, dtau, (scalar_t*)dev_work, lwork ));
+
+    // todo: default info returned
+    blas::device_memset( dev_info, 0, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void geqrf_work_size_bytes(
+    int64_t m, int64_t n,
+    float* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void geqrf_work_size_bytes(
+    int64_t m, int64_t n,
+    double* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void geqrf_work_size_bytes(
+    int64_t m, int64_t n,
+    std::complex<float>* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void geqrf_work_size_bytes(
+    int64_t m, int64_t n,
+    std::complex<double>* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+//--------------------
+template
+void geqrf(
+    int64_t m, int64_t n,
+    float* dA, int64_t ldda, float* dtau,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void geqrf(
+    int64_t m, int64_t n,
+    double* dA, int64_t ldda, double* dtau,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void geqrf(
+    int64_t m, int64_t n,
+    std::complex<float>* dA, int64_t ldda, std::complex<float>* dtau,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void geqrf(
+    int64_t m, int64_t n,
+    std::complex<double>* dA, int64_t ldda, std::complex<double>* dtau,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+} // namespace lapack
+
+#endif // LAPACK_HAVE_ONEMKL

--- a/src/onemkl/onemkl_getrf.cc
+++ b/src/onemkl/onemkl_getrf.cc
@@ -1,0 +1,129 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "lapack/defines.h"
+
+#if defined(LAPACK_HAVE_ONEMKL)
+
+#include "onemkl_common.hh"
+
+//==============================================================================
+namespace lapack {
+
+//------------------------------------------------------------------------------
+// Wrapper around workspace query.
+// dA is only for templating scalar_t; it isn't referenced.
+template <typename scalar_t>
+void getrf_work_size_bytes(
+    int64_t m, int64_t n,
+    scalar_t* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    auto solver = queue.handle();
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    int lwork = 0;
+    blas_dev_call(
+        lwork = oneapi::mkl::lapack::getrf_scratchpad_size<scalar_t>(
+            solver, m, n, ldda ));
+    *dev_work_size = lwork * sizeof(scalar_t);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Wrapper around cuSolver.
+// This is async. Once finished, the return info is in dev_info on the device.
+template <typename scalar_t>
+void getrf(
+    int64_t m, int64_t n,
+    scalar_t* dA, int64_t ldda, device_pivot_int* dipiv,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    auto solver = queue.handle();
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    // launch kernel
+    int64_t lwork = dev_work_size/sizeof(scalar_t);
+    blas_dev_call(
+        oneapi::mkl::lapack::getrf(
+            solver, m, n, dA, ldda, dipiv, (scalar_t*) dev_work, lwork ));
+
+    // todo: default info returned
+    blas::device_memset( dev_info, 0, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void getrf_work_size_bytes(
+    int64_t m, int64_t n,
+    float* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void getrf_work_size_bytes(
+    int64_t m, int64_t n,
+    double* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void getrf_work_size_bytes(
+    int64_t m, int64_t n,
+    std::complex<float>* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void getrf_work_size_bytes(
+    int64_t m, int64_t n,
+    std::complex<double>* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+//--------------------
+template
+void getrf(
+    int64_t m, int64_t n,
+    float* dA, int64_t ldda, device_pivot_int* dipiv,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void getrf(
+    int64_t m, int64_t n,
+    double* dA, int64_t ldda, device_pivot_int* dipiv,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void getrf(
+    int64_t m, int64_t n,
+    std::complex<float>* dA, int64_t ldda, device_pivot_int* dipiv,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void getrf(
+    int64_t m, int64_t n,
+    std::complex<double>* dA, int64_t ldda, device_pivot_int* dipiv,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+} // namespace lapack
+
+#endif // LAPACK_HAVE_ONEMKL

--- a/src/onemkl/onemkl_getrf.cc
+++ b/src/onemkl/onemkl_getrf.cc
@@ -22,7 +22,7 @@ void getrf_work_size_bytes(
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue )
 {
-    auto solver = queue.handle();
+    auto solver = queue.stream();
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );
@@ -46,7 +46,7 @@ void getrf(
     void* host_work, size_t host_work_size,
     device_info_int* dev_info, lapack::Queue& queue )
 {
-    auto solver = queue.handle();
+    auto solver = queue.stream();
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );

--- a/src/onemkl/onemkl_potrf.cc
+++ b/src/onemkl/onemkl_potrf.cc
@@ -1,0 +1,113 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "lapack/defines.h"
+
+#if defined(LAPACK_HAVE_ONEMKL)
+
+#include "onemkl_common.hh"
+
+//==============================================================================
+// todo: put into BLAS++ header somewhere.
+
+namespace blas {
+namespace device {
+
+oneapi::mkl::uplo uplo2onemkl(blas::Uplo uplo);
+
+} // namespace device
+} // namespace blas
+
+//==============================================================================
+namespace lapack {
+
+//------------------------------------------------------------------------------
+// Wrapper around workspace query.
+template <typename scalar_t>
+void potrf_work_size_bytes(
+    lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    auto solver = queue.handle();
+    auto uplo_ = blas::device::uplo2onemkl( uplo );
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    // query for workspace size
+    int64_t lwork = 0;
+    blas_dev_call(
+        lwork = oneapi::mkl::lapack::potrf_scratchpad_size<scalar_t>(
+            solver, uplo_, n, ldda ));
+    *dev_work_size = lwork * sizeof(scalar_t);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Wrapper around cuSolver.
+// This is async. Once finished, the return info is in dev_info on the device.
+template <typename scalar_t>
+void potrf(
+    lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    auto solver = queue.handle();
+    auto uplo_ = blas::device::uplo2onemkl( uplo );
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    // query for workspace size
+    size_t dev_work_size, host_work_size;
+    potrf_work_size_bytes(
+        uplo, n, dA, ldda, &dev_work_size, &host_work_size, queue );
+
+    // alloc workspace in queue
+    queue.work_resize< char >( dev_work_size );  // syncs if needed
+    void* dev_work = queue.work();
+    blas_error_if( host_work_size != 0 );
+
+    // launch kernel
+    int64_t lwork = dev_work_size/sizeof(scalar_t);
+    blas_dev_call(
+        oneapi::mkl::lapack::potrf(
+            solver, uplo_, n, dA, ldda, (scalar_t*)dev_work, lwork ));
+
+    // todo: default info returned
+    blas::device_memset( dev_info, 0, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void potrf(
+    lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void potrf(
+    lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void potrf(
+    lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void potrf(
+    lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+} // namespace lapack
+
+#endif // LAPACK_HAVE_ONEMKL

--- a/src/onemkl/onemkl_potrf.cc
+++ b/src/onemkl/onemkl_potrf.cc
@@ -32,7 +32,7 @@ void potrf_work_size_bytes(
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue )
 {
-    auto solver = queue.handle();
+    auto solver = queue.stream();
     auto uplo_ = blas::device::uplo2onemkl( uplo );
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
@@ -56,7 +56,7 @@ void potrf(
     scalar_t* dA, int64_t ldda,
     device_info_int* dev_info, lapack::Queue& queue )
 {
-    auto solver = queue.handle();
+    auto solver = queue.stream();
     auto uplo_ = blas::device::uplo2onemkl( uplo );
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.

--- a/src/onemkl/onemkl_potrf.cc
+++ b/src/onemkl/onemkl_potrf.cc
@@ -57,7 +57,7 @@ void potrf(
     device_info_int* dev_info, lapack::Queue& queue )
 {
     auto solver = queue.stream();
-    auto uplo_ = blas::device::uplo2onemkl( uplo );
+    auto uplo_ = blas::internal::uplo2onemkl( uplo );
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );

--- a/src/onemkl/onemkl_potrf.cc
+++ b/src/onemkl/onemkl_potrf.cc
@@ -33,7 +33,7 @@ void potrf_work_size_bytes(
     lapack::Queue& queue )
 {
     auto solver = queue.stream();
-    auto uplo_ = blas::device::uplo2onemkl( uplo );
+    auto uplo_ = blas::internal::uplo2onemkl( uplo );
 
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );

--- a/src/onemkl/onemkl_potrf.cc
+++ b/src/onemkl/onemkl_potrf.cc
@@ -13,11 +13,11 @@
 // todo: put into BLAS++ header somewhere.
 
 namespace blas {
-namespace device {
+namespace internal {
 
 oneapi::mkl::uplo uplo2onemkl(blas::Uplo uplo);
 
-} // namespace device
+} // namespace internal
 } // namespace blas
 
 //==============================================================================


### PR DESCRIPTION
Testing lapackpp on jlse-arcticus.
module load -f oneapi/eng-compiler/2022.12.30.002
qsub -t 60 -n 1 -q arcticus -I
cd ~/icl/slate-dev/lapackpp/test/
./run_tests.py --quick

Before this PR, on Intel-jlse-arcticus
10 routines FAILED: dev-getrf, dev-potrf, dev-geqrf, hpev, hpevx, hpevx, hptrd, hpgv, hpgvx, geev
Fri Jan  6 17:36:33 2023

After this PR, on arcticus the device routines (dev-getrf, dev-potrf, dev-geqrf) now pass.
6 routines FAILED: hpev, hpevx, hpevx, hpgv, hpgvx, geev
Sun Jan  8 00:50:44 2023
