### PR TITLE
Add missing config executables to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,12 @@
 __pycache__
 lapackpp-*
 build*
+config/acml_version
 config/blas
 config/cblas
 config/compiler_cxx
 config/cublas
+config/essl_version
 config/hello
 config/lapack_matgen
 config/lapack_potrf
@@ -24,11 +26,13 @@ config/lapacke_potrf
 config/lapacke_pstrf
 config/log.txt
 config/mkl_version
+config/onemkl
 config/openblas_version
 config/openmp
 config/return_complex
 config/return_complex_argument
 config/return_float
+config/return_float_f2c
 config/rocblas
 docs/doxygen/errors.txt
 docs/html/


### PR DESCRIPTION
.gitignore was missing a few of the config executables, particularly `config/essl_version` on Summit. This adds the missing files to .gitignore.

Cf. https://github.com/icl-utk-edu/blaspp/pull/27