### PR TITLE
ci: simplify CMAKE_PREFIX_PATH

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -6,14 +6,15 @@ device=$2
 mydir=$(dirname $0)
 source ${mydir}/setup_env.sh
 
-print "======================================== Tests"
-
 # Instead of exiting on the first failed test (bash -e),
 # run all the tests and accumulate failures into $err.
 err=0
 
-cd test
 export OMP_NUM_THREADS=8
+
+print "======================================== Tests"
+cd test
+
 ./run_tests.py --host --quick --xml ${top}/report-${maker}.xml
 (( err += $? ))
 
@@ -30,10 +31,7 @@ if [ "${maker}" = "make" ]; then
 fi
 if [ "${maker}" = "cmake" ]; then
     rm -rf build && mkdir build && cd build
-    # On some systems, CMake GNUInstallDirs uses lib, on others lib64.
-    lib="${top}/install/lib/blaspp;${top}/install/lib/lapackpp"
-    lib64="${top}/install/lib64/blaspp;${top}/install/lib64/lapackpp"
-    cmake "-DCMAKE_PREFIX_PATH=${lib};${lib64}" ..
+    cmake "-DCMAKE_PREFIX_PATH=${top}/install" ..
 fi
 
 make


### PR DESCRIPTION
Previously, I thought CMAKE_PREFIX_PATH had to point to the specific package's directory:
```
${top}/install/lib/blaspp
```
but found that pointing to the install directory is sufficient:
```
${top}/install
```
which greatly simplifies scripts when there are multiple packages to point to.