### PR TITLE
search for ROCm or CUDA

### DIFF
--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -52,8 +52,6 @@ if [ "${device}" = "gpu_nvidia" ]; then
     print "======================================== Load CUDA"
     export CUDA_HOME=/usr/local/cuda/
     export PATH=${PATH}:${CUDA_HOME}/bin
-    #export CPATH=${CPATH}:${CUDA_HOME}/include
-    #export LIBRARY_PATH=${LIBRARY_PATH}:${CUDA_HOME}/lib64
     export gpu_backend=cuda
     quiet which nvcc
     nvcc --version
@@ -62,9 +60,6 @@ fi
 if [ "${device}" = "gpu_amd" ]; then
     print "======================================== Load ROCm"
     export PATH=${PATH}:/opt/rocm/bin
-    #export CPATH=${CPATH}:/opt/rocm/include
-    #export LIBRARY_PATH=${LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
-    #export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
     export gpu_backend=hip
     quiet which hipcc
     hipcc --version

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -52,8 +52,8 @@ if [ "${device}" = "gpu_nvidia" ]; then
     print "======================================== Load CUDA"
     export CUDA_HOME=/usr/local/cuda/
     export PATH=${PATH}:${CUDA_HOME}/bin
-    export CPATH=${CPATH}:${CUDA_HOME}/include
-    export LIBRARY_PATH=${LIBRARY_PATH}:${CUDA_HOME}/lib64
+    #export CPATH=${CPATH}:${CUDA_HOME}/include
+    #export LIBRARY_PATH=${LIBRARY_PATH}:${CUDA_HOME}/lib64
     export gpu_backend=cuda
     quiet which nvcc
     nvcc --version
@@ -62,9 +62,9 @@ fi
 if [ "${device}" = "gpu_amd" ]; then
     print "======================================== Load ROCm"
     export PATH=${PATH}:/opt/rocm/bin
-    export CPATH=${CPATH}:/opt/rocm/include
-    export LIBRARY_PATH=${LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
+    #export CPATH=${CPATH}:/opt/rocm/include
+    #export LIBRARY_PATH=${LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
+    #export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
     export gpu_backend=hip
     quiet which hipcc
     hipcc --version

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,9 @@ These include:
     LIBRARY_PATH        compile-time library search path
     LD_LIBRARY_PATH     runtime library search path
     DYLD_LIBRARY_PATH   runtime library search path on macOS
+    CUDA_PATH           path to CUDA, e.g., /usr/local/cuda
+    CUDA_HOME           also recognized for path to CUDA
+    ROCM_PATH           path to ROCm, e.g., /opt/rocm
 
 
 Options (Makefile and CMake)

--- a/config/config.py
+++ b/config/config.py
@@ -641,12 +641,14 @@ def cublas_library():
 
     if (cuda_path):
         incdir = os.path.join( cuda_path, 'include' )
-        cxxflags += ' -I' + incdir
+        if (os.path.exists( incdir )):
+            cxxflags += ' -I' + incdir
 
         libdir = os.path.join( cuda_path, 'lib64' )
         if (not os.path.exists( libdir )):
             libdir = os.path.join( cuda_path, 'lib' )
-        ldflags += '-L' + libdir + ' -Wl,-rpath,' + libdir
+        if (os.path.exists( libdir )):
+            ldflags += '-L' + libdir + ' -Wl,-rpath,' + libdir
     # end
 
     print_subhead( 'CUDA and cuBLAS libraries' )
@@ -683,14 +685,16 @@ def rocblas_library():
 
     if (rocm_path):
         incdir = os.path.join( rocm_path, 'include' )
-        cxxflags += ' -I' + incdir
+        if (os.path.exists( incdir )):
+            cxxflags += ' -I' + incdir
 
         # Some versions of ROCm (5.1.3) have both lib and lib64 directories;
         # we need the lib directory.
         libdir = os.path.join( rocm_path, 'lib' )
         if (not os.path.exists( libdir )):
             libdir = os.path.join( rocm_path, 'lib64' )
-        ldflags += ' -L' + libdir + ' -Wl,-rpath,' + libdir
+        if (os.path.exists( libdir )):
+            ldflags += ' -L' + libdir + ' -Wl,-rpath,' + libdir
     # end
 
     print_subhead( 'HIP/ROCm and rocBLAS libraries' )

--- a/config/config.py
+++ b/config/config.py
@@ -15,6 +15,7 @@ import time
 import re
 import tarfile
 import argparse
+import shutil
 
 # This relative import syntax works in both python2 and 3.
 from .ansicodes import font
@@ -621,10 +622,36 @@ def cublas_library():
     Does not actually run the resulting exe, to allow compiling with CUDA on a
     machine without GPUs.
     '''
-    libs = '-lcusolver -lcublas -lcudart'
+    # Find CUDA to add -I, -L, -rpath flags.
+    # CUDA_PATH is used in NVIDIA Getting Started documentation;
+    # CUDA_HOME is used in Spack CUDA package;
+    # else infer from `which nvcc`.
+    cuda_path = environ['CUDA_PATH']
+    if (not cuda_path):
+        cuda_path = environ['CUDA_HOME']
+    if (not cuda_path):
+        nvcc_path = shutil.which( 'nvcc' )
+        if (nvcc_path):
+            (bin_path, nvcc) = os.path.split( nvcc_path )
+            (cuda_path, bin_) = os.path.split( bin_path )
+
+    cxxflags = define('HAVE_CUBLAS')
+    ldflags  = ''
+    libs     = '-lcusolver -lcublas -lcudart'
+
+    if (cuda_path):
+        incdir = os.path.join( cuda_path, 'include' )
+        cxxflags += ' -I' + incdir
+
+        libdir = os.path.join( cuda_path, 'lib64' )
+        if (not os.path.exists( libdir )):
+            libdir = os.path.join( cuda_path, 'lib' )
+        ldflags += '-L' + libdir + ' -Wl,-rpath,' + libdir
+    # end
+
     print_subhead( 'CUDA and cuBLAS libraries' )
-    print_test( '    ' + libs )
-    env = {'LIBS': libs, 'CXXFLAGS': define('HAVE_CUBLAS')}
+    print_test( '    ' + cxxflags + ' ' + ldflags + ' ' + libs )
+    env = {'CXXFLAGS': cxxflags, 'LDFLAGS': ldflags, 'LIBS': libs}
     (rc, out, err) = compile_exe( 'config/cublas.cc', env )
     print_result( libs, rc )
     if (rc == 0):
@@ -640,11 +667,35 @@ def rocblas_library():
     Does not actually run the resulting exe, to allow compiling with ROCm on a
     machine without GPUs.
     '''
-    libs = '-lrocsolver -lrocblas -lamdhip64'
+    # Find ROCm to add -I, -L, -rpath flags.
+    # ROCM_PATH is used in hipcc and Spack ROCm package;
+    # else infer from `which hipcc`.
+    rocm_path = environ['ROCM_PATH']
+    if (not rocm_path):
+        hipcc_path = shutil.which( 'hipcc' )
+        if (hipcc_path):
+            (bin_path, hipcc) = os.path.split( hipcc_path )
+            (rocm_path, bin_) = os.path.split( bin_path )
+
+    cxxflags = define('HAVE_ROCBLAS')
+    ldflags  = ''
+    libs     = '-lrocsolver -lrocblas -lamdhip64'
+
+    if (rocm_path):
+        incdir = os.path.join( rocm_path, 'include' )
+        cxxflags += ' -I' + incdir
+
+        # Some versions of ROCm (5.1.3) have both lib and lib64 directories;
+        # we need the lib directory.
+        libdir = os.path.join( rocm_path, 'lib' )
+        if (not os.path.exists( libdir )):
+            libdir = os.path.join( rocm_path, 'lib64' )
+        ldflags += ' -L' + libdir + ' -Wl,-rpath,' + libdir
+    # end
+
     print_subhead( 'HIP/ROCm and rocBLAS libraries' )
-    print_test( '    ' + libs )
-    env = {'LIBS': libs,
-           'CXXFLAGS': define('HAVE_ROCBLAS')}
+    print_test( '    ' + cxxflags + ' ' + ldflags + ' ' + libs )
+    env = {'CXXFLAGS': cxxflags, 'LDFLAGS': ldflags, 'LIBS': libs}
     (rc, out, err) = compile_exe( 'config/rocblas.cc', env )
     print_result( libs, rc )
     if (rc == 0):

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -115,7 +115,7 @@ group_opt.add_argument( '--equed',  action='store', help='default=%(default)s', 
 group_opt.add_argument( '--direction', action='store', help='default=%(default)s', default='f,b' )
 group_opt.add_argument( '--storev', action='store', help='default=%(default)s', default='c,r' )
 group_opt.add_argument( '--norm',   action='store', help='default=%(default)s', default='max,1,inf,fro' )
-group_opt.add_argument( '--ijob',   action='store', help='default=%(default)s', default='0:5' )
+group_opt.add_argument( '--ijob',   action='store', help='default=%(default)s', default='0:5:1' )
 group_opt.add_argument( '--jobz',   action='store', help='default=%(default)s', default='n,v' )
 group_opt.add_argument( '--jobvl',  action='store', help='default=%(default)s', default='n,v' )
 group_opt.add_argument( '--jobvr',  action='store', help='default=%(default)s', default='n,v' )


### PR DESCRIPTION
Instead of requiring the user to add CUDA and ROCm to CFLAGS, LIBRARY_PATH, LD_LIBRARY_PATH, this does a quick search for them and adds the appropriate `-I`, `-L`, and `-rpath` flags. (CMake already does this.)

Similar changes are in [BLAS++ PR 51](https://github.com/icl-utk-edu/blaspp/pull/51) and [SLATE PR 69](https://github.com/icl-utk-edu/slate/pull/69).