### PR TITLE
Add Device Implementation of `HEEVD`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,7 @@ add_library(
     src/stub/stub_geqrf.cc
     src/stub/stub_getrf.cc
     src/stub/stub_potrf.cc
+    src/stub/stub_heevd.cc
 )
 
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,6 +523,7 @@ add_library(
     src/cuda/cuda_geqrf.cc
     src/cuda/cuda_getrf.cc
     src/cuda/cuda_potrf.cc
+    src/cuda/cuda_heevd.cc
 
     src/rocm/rocm_geqrf.cc
     src/rocm/rocm_getrf.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,6 +528,7 @@ add_library(
     src/rocm/rocm_geqrf.cc
     src/rocm/rocm_getrf.cc
     src/rocm/rocm_potrf.cc
+    src/rocm/rocm_heevd.cc
 
     src/onemkl/onemkl_geqrf.cc
     src/onemkl/onemkl_getrf.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,7 @@ add_library(
     src/onemkl/onemkl_geqrf.cc
     src/onemkl/onemkl_getrf.cc
     src/onemkl/onemkl_potrf.cc
+    src/onemkl/onemkl_heevd.cc
 
     src/stub/stub_geqrf.cc
     src/stub/stub_getrf.cc

--- a/include/lapack/device.hh
+++ b/include/lapack/device.hh
@@ -178,6 +178,22 @@ void geqrf(
     void* host_work, size_t host_work_size,
     device_info_int* dev_info, lapack::Queue& queue );
 
+//------------------------------------------------------------------------------
+template <typename scalar_t>
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template <typename scalar_t>
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
 }  // namespace lapack
 
 #endif // LAPACK_DEVICE_HH

--- a/include/lapack/device.hh
+++ b/include/lapack/device.hh
@@ -181,7 +181,7 @@ void geqrf(
 //------------------------------------------------------------------------------
 template <typename scalar_t>
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );

--- a/src/cuda/cuda_common.cc
+++ b/src/cuda/cuda_common.cc
@@ -104,14 +104,16 @@ const char* device_error_string( cusolverStatus_t error )
 
 
 namespace lapack {
-cusolverEigMode_t job2eigmode_cusolver(lapack::Job job) 
+
+cusolverEigMode_t job2eigmode_cusolver(lapack::Job job)
 {
     switch (job) {
         case lapack::Job::NoVec : return CUSOLVER_EIG_MODE_NOVECTOR;
-        case lapack::Job::Vec   : return CUSOLVER_EIG_MODE_VECTOR;  
+        case lapack::Job::Vec   : return CUSOLVER_EIG_MODE_VECTOR;
         default: throw blas::Error( "unknown job" );
     }
 }
+
 } // namespace lapack
 
 #endif // LAPACK_HAVE_CUBLAS

--- a/src/cuda/cuda_common.cc
+++ b/src/cuda/cuda_common.cc
@@ -102,4 +102,16 @@ const char* device_error_string( cusolverStatus_t error )
 
 } // namespace blas
 
+
+namespace lapack {
+cusolverEigMode_t job2eigmode_cusolver(lapack::Job job) 
+{
+    switch (job) {
+        case lapack::Job::NoVec : return CUSOLVER_EIG_MODE_NOVECTOR;
+        case lapack::Job::Vec   : return CUSOLVER_EIG_MODE_VECTOR;  
+        default: throw blas::Error( "unknown job" );
+    }
+}
+} // namespace lapack
+
 #endif // LAPACK_HAVE_CUBLAS

--- a/src/cuda/cuda_common.hh
+++ b/src/cuda/cuda_common.hh
@@ -45,6 +45,8 @@ public:
     static constexpr cudaDataType datatype = CUDA_C_64F;
 };
 
+cusolverEigMode_t job2eigmode_cusolver(lapack::Job job);
+
 } // namespace lapack
 
 //==============================================================================

--- a/src/cuda/cuda_heevd.cc
+++ b/src/cuda/cuda_heevd.cc
@@ -1,0 +1,249 @@
+
+#include "lapack/defines.h"
+
+#if defined(LAPACK_HAVE_CUBLAS)
+
+#include "lapack/device.hh"
+#include "cuda_common.hh"
+
+namespace blas {
+namespace internal {
+cublasFillMode_t uplo2cublas(blas::Uplo uplo);
+}
+}
+
+
+//==============================================================================
+namespace lapack {
+
+//------------------------------------------------------------------------------
+// Intermediate wrappers around cuSolver to deal with precisions.
+cusolverStatus_t cusolver_heevd_bufferSize(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo, int n, float* dA, 
+    int ldda, float* dW, int* lwork )
+{
+    return cusolverDnSsyevd_bufferSize(
+        solver, jobz, uplo, n, dA, ldda, dW, lwork );
+}
+
+//----------
+cusolverStatus_t cusolver_heevd_bufferSize(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo,int n, double* dA, 
+    int ldda, double* dW, int* lwork )
+{
+    return cusolverDnDsyevd_bufferSize(
+        solver, jobz, uplo, n, dA, ldda, dW, lwork );
+}
+
+//----------
+cusolverStatus_t cusolver_heevd_bufferSize(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo,int n, std::complex<float>* dA, 
+    int ldda, float* dW, int* lwork )
+{
+    return cusolverDnCheevd_bufferSize(
+        solver, jobz, uplo, n,
+        (cuFloatComplex*) dA, ldda, dW, lwork );
+}
+
+//----------
+cusolverStatus_t cusolver_heevd_bufferSize(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo,int n, std::complex<double>* dA, 
+    int ldda, double* dW, int* lwork )
+{
+    return cusolverDnZheevd_bufferSize(
+        solver, jobz, uplo, n,
+        (cuDoubleComplex*) dA, ldda, dW, lwork );
+}
+
+//------------------------------------------------------------------------------
+// Intermediate wrappers around cuSolver to deal with precisions.
+cusolverStatus_t cusolver_heevd(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo, int n, float* dA, 
+    int ldda, float* dW, float* dev_work, int lwork, int* info )
+{
+    return cusolverDnSsyevd(
+        solver, jobz, uplo, n, dA, ldda, dW, dev_work, lwork, info );
+}
+
+//----------
+cusolverStatus_t cusolver_heevd(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo, int n, double* dA, 
+    int ldda, double* dW, double* dev_work, int lwork, int* info )
+{
+    return cusolverDnDsyevd(
+        solver, jobz, uplo, n, dA, ldda, dW, dev_work, lwork, info );
+}
+
+//----------
+cusolverStatus_t cusolver_heevd(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo, int n, std::complex<float>* dA, 
+    int ldda, float* dW, float* dev_work, int lwork, int* info )
+{
+    return cusolverDnCheevd(
+        solver, jobz, uplo, n,
+        (cuFloatComplex*) dA, ldda,
+        dW,
+        (cuFloatComplex*) dev_work, lwork, info );
+}
+
+//----------
+cusolverStatus_t cusolver_heevd(
+    cusolverDnHandle_t solver, cusolverEigMode_t jobz,
+    cublasFillMode_t uplo, int n, std::complex<double>* dA, 
+    int ldda, double* dW, double* dev_work, int lwork, int* info )
+{
+    return cusolverDnZheevd(
+        solver, jobz, uplo, n,
+        (cuDoubleComplex*) dA, ldda,
+        dW,
+        (cuDoubleComplex*) dev_work, lwork, info );
+}
+
+//------------------------------------------------------------------------------
+// Wrapper around cuSolver workspace query.
+// dA is only for templating scalar_t; it isn't referenced.
+template <typename scalar_t>
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    using real_t = blas::real_type<scalar_t>;
+    auto solver = queue.solver();
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    // query for workspace size
+    #if CUSOLVER_VERSION >= 11000
+        auto params = queue.solver_params();
+        blas_dev_call(
+            cusolverDnXsyevd_bufferSize(
+                solver, params, job2eigmode_cusolver(jobz), 
+                blas::internal::uplo2cublas(uplo), n,
+                CudaTraits<scalar_t>::datatype, dA, ldda,
+                CudaTraits<real_t>  ::datatype, dW,
+                CudaTraits<scalar_t>::datatype,
+                dev_work_size, host_work_size));
+    #else
+        int lwork;
+        blas_dev_call(
+            cusolver_heevd_bufferSize( solver, job2eigmode_cusolver(jobz), blas::internal::uplo2cublas(uplo), n, dA, ldda, dW, &lwork ));
+        *dev_work_size = lwork * sizeof(scalar_t);
+        *host_work_size = 0;
+    #endif
+}
+
+//------------------------------------------------------------------------------
+// Wrapper around cuSolver.
+// This is async. Once finished, the return info is in dev_info on the device.
+template <typename scalar_t>
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    using real_t = blas::real_type<scalar_t>;
+    auto solver = queue.solver();
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    // launch kernel
+    #if CUSOLVER_VERSION >= 11000
+        auto params = queue.solver_params();
+        blas_dev_call(
+            cusolverDnXsyevd(
+                solver, params, job2eigmode_cusolver(jobz), 
+                blas::internal::uplo2cublas(uplo), n,
+                CudaTraits<scalar_t>::datatype, dA, ldda,
+                CudaTraits<real_t>  ::datatype, dW,
+                CudaTraits<scalar_t>::datatype,
+                dev_work, dev_work_size,
+                host_work, host_work_size, dev_info ));
+    #else
+        int lwork = dev_work_size / sizeof(scalar_t);
+        blas_dev_call(
+            cusolver_heevd(
+                solver, params, job2eigmode_cusolver(jobz), blas::internal::uplo2cublas(uplo), n, dA, ldda, dW,
+                (scalar_t*) dev_work, lwork, dev_info ));
+    #endif
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, float* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, double* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, std::complex<float>* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, std::complex<double>* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+//--------------------
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+} // namespace lapack
+
+#endif // LAPACK_HAVE_CUBLAS
+

--- a/src/cuda/cuda_heevd.cc
+++ b/src/cuda/cuda_heevd.cc
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include "lapack/defines.h"
 
@@ -6,12 +10,14 @@
 #include "lapack/device.hh"
 #include "cuda_common.hh"
 
+//==============================================================================
 namespace blas {
 namespace internal {
-cublasFillMode_t uplo2cublas(blas::Uplo uplo);
-}
-}
 
+cublasFillMode_t uplo2cublas(blas::Uplo uplo);
+
+} // namespace internal
+} // namespace blas
 
 //==============================================================================
 namespace lapack {
@@ -20,7 +26,7 @@ namespace lapack {
 // Intermediate wrappers around cuSolver to deal with precisions.
 cusolverStatus_t cusolver_heevd_bufferSize(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo, int n, float* dA, 
+    cublasFillMode_t uplo, int n, float* dA,
     int ldda, float* dW, int* lwork )
 {
     return cusolverDnSsyevd_bufferSize(
@@ -30,7 +36,7 @@ cusolverStatus_t cusolver_heevd_bufferSize(
 //----------
 cusolverStatus_t cusolver_heevd_bufferSize(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo,int n, double* dA, 
+    cublasFillMode_t uplo, int n, double* dA,
     int ldda, double* dW, int* lwork )
 {
     return cusolverDnDsyevd_bufferSize(
@@ -40,7 +46,7 @@ cusolverStatus_t cusolver_heevd_bufferSize(
 //----------
 cusolverStatus_t cusolver_heevd_bufferSize(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo,int n, std::complex<float>* dA, 
+    cublasFillMode_t uplo, int n, std::complex<float>* dA,
     int ldda, float* dW, int* lwork )
 {
     return cusolverDnCheevd_bufferSize(
@@ -51,7 +57,7 @@ cusolverStatus_t cusolver_heevd_bufferSize(
 //----------
 cusolverStatus_t cusolver_heevd_bufferSize(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo,int n, std::complex<double>* dA, 
+    cublasFillMode_t uplo, int n, std::complex<double>* dA,
     int ldda, double* dW, int* lwork )
 {
     return cusolverDnZheevd_bufferSize(
@@ -63,7 +69,7 @@ cusolverStatus_t cusolver_heevd_bufferSize(
 // Intermediate wrappers around cuSolver to deal with precisions.
 cusolverStatus_t cusolver_heevd(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo, int n, float* dA, 
+    cublasFillMode_t uplo, int n, float* dA,
     int ldda, float* dW, float* dev_work, int lwork, int* info )
 {
     return cusolverDnSsyevd(
@@ -73,7 +79,7 @@ cusolverStatus_t cusolver_heevd(
 //----------
 cusolverStatus_t cusolver_heevd(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo, int n, double* dA, 
+    cublasFillMode_t uplo, int n, double* dA,
     int ldda, double* dW, double* dev_work, int lwork, int* info )
 {
     return cusolverDnDsyevd(
@@ -83,7 +89,7 @@ cusolverStatus_t cusolver_heevd(
 //----------
 cusolverStatus_t cusolver_heevd(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo, int n, std::complex<float>* dA, 
+    cublasFillMode_t uplo, int n, std::complex<float>* dA,
     int ldda, float* dW, float* dev_work, int lwork, int* info )
 {
     return cusolverDnCheevd(
@@ -96,7 +102,7 @@ cusolverStatus_t cusolver_heevd(
 //----------
 cusolverStatus_t cusolver_heevd(
     cusolverDnHandle_t solver, cusolverEigMode_t jobz,
-    cublasFillMode_t uplo, int n, std::complex<double>* dA, 
+    cublasFillMode_t uplo, int n, std::complex<double>* dA,
     int ldda, double* dW, double* dev_work, int lwork, int* info )
 {
     return cusolverDnZheevd(
@@ -111,7 +117,7 @@ cusolverStatus_t cusolver_heevd(
 // dA is only for templating scalar_t; it isn't referenced.
 template <typename scalar_t>
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue )
@@ -127,7 +133,7 @@ void heevd_work_size_bytes(
         auto params = queue.solver_params();
         blas_dev_call(
             cusolverDnXsyevd_bufferSize(
-                solver, params, job2eigmode_cusolver(jobz), 
+                solver, params, job2eigmode_cusolver(jobz),
                 blas::internal::uplo2cublas(uplo), n,
                 CudaTraits<scalar_t>::datatype, dA, ldda,
                 CudaTraits<real_t>  ::datatype, dW,
@@ -164,7 +170,7 @@ void heevd(
         auto params = queue.solver_params();
         blas_dev_call(
             cusolverDnXsyevd(
-                solver, params, job2eigmode_cusolver(jobz), 
+                solver, params, job2eigmode_cusolver(jobz),
                 blas::internal::uplo2cublas(uplo), n,
                 CudaTraits<scalar_t>::datatype, dA, ldda,
                 CudaTraits<real_t>  ::datatype, dW,
@@ -184,28 +190,28 @@ void heevd(
 // Explicit instantiations.
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, float* dA, int64_t ldda, float* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );
 
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, double* dA, int64_t ldda, double* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );
 
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, std::complex<float>* dA, int64_t ldda, float* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );
 
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, std::complex<double>* dA, int64_t ldda, double* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );

--- a/src/onemkl/onemkl_common.hh
+++ b/src/onemkl/onemkl_common.hh
@@ -18,14 +18,14 @@
 
 namespace lapack {
 
-// todo: Move to blaspp/src/onemkl_wrappers.cc as blas::internal::jobz2onemkl()?
-inline const oneapi::mkl::job jobz2onemkl(lapack::Job jobz) {
-    if (jobz == lapack::Job::NoVec) return oneapi::mkl::job::novec;
-    if (jobz == lapack::Job::Vec) return oneapi::mkl::job::vec;
-    if (jobz == lapack::Job::UpdateVec) return oneapi::mkl::job::updatevec;
-    if (jobz == lapack::Job::AllVec) return oneapi::mkl::job::allvec;
-    if (jobz == lapack::Job::SomeVec) return oneapi::mkl::job::somevec;
-    if (jobz == lapack::Job::OverwriteVec) return oneapi::mkl::job::overwritevec;
+inline const oneapi::mkl::job job2onemkl( lapack::Job job )
+{
+    if (job == lapack::Job::NoVec) return oneapi::mkl::job::novec;
+    if (job == lapack::Job::Vec) return oneapi::mkl::job::vec;
+    if (job == lapack::Job::UpdateVec) return oneapi::mkl::job::updatevec;
+    if (job == lapack::Job::AllVec) return oneapi::mkl::job::allvec;
+    if (job == lapack::Job::SomeVec) return oneapi::mkl::job::somevec;
+    if (job == lapack::Job::OverwriteVec) return oneapi::mkl::job::overwritevec;
     return oneapi::mkl::job::novec;
 }
 

--- a/src/onemkl/onemkl_common.hh
+++ b/src/onemkl/onemkl_common.hh
@@ -16,4 +16,19 @@
 
 #include <oneapi/mkl.hpp>
 
+namespace lapack {
+
+// todo: Move to blaspp/src/onemkl_wrappers.cc as blas::internal::jobz2onemkl()?
+inline const oneapi::mkl::job jobz2onemkl(lapack::Job jobz) {
+    if (jobz == lapack::Job::NoVec) return oneapi::mkl::job::novec;
+    if (jobz == lapack::Job::Vec) return oneapi::mkl::job::vec;
+    if (jobz == lapack::Job::UpdateVec) return oneapi::mkl::job::updatevec;
+    if (jobz == lapack::Job::AllVec) return oneapi::mkl::job::allvec;
+    if (jobz == lapack::Job::SomeVec) return oneapi::mkl::job::somevec;
+    if (jobz == lapack::Job::OverwriteVec) return oneapi::mkl::job::overwritevec;
+    return oneapi::mkl::job::novec;
+}
+
+} // namespace lapack
+
 #endif // LAPACK_ONEMKL_COMMON_H

--- a/src/onemkl/onemkl_heevd.cc
+++ b/src/onemkl/onemkl_heevd.cc
@@ -1,0 +1,275 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "lapack/defines.h"
+
+#if defined(LAPACK_HAVE_SYCL)
+
+#include "lapack/device.hh"
+#include "onemkl_common.hh"
+
+//==============================================================================
+namespace blas {
+namespace internal {
+
+// Access function blas::internal::uplo2onemkl()
+oneapi::mkl::uplo uplo2onemkl(blas::Uplo uplo);
+
+} // namespace internal
+} // namespace blas
+
+//==============================================================================
+namespace lapack {
+
+//==============================================================================
+// Specified scalar_t float -> syevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    int lwork = 0;
+    lwork = oneapi::mkl::lapack::syevd_scratchpad_size<float>(
+        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+    *dev_work_size = lwork * sizeof(float);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Specified scalar_t double -> syevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    int lwork = 0;
+    lwork = oneapi::mkl::lapack::syevd_scratchpad_size<double>(
+        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+    *dev_work_size = lwork * sizeof(double);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Specified scalar_t std::complex<float> -> heevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    int lwork = 0;
+    lwork = oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<float>>(
+        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+    *dev_work_size = lwork * sizeof(std::complex<float>);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Specified scalar_t std::complex<double> -> heevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    int lwork = 0;
+    lwork = oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<double>>(
+        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+    *dev_work_size = lwork * sizeof(std::complex<double>);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Templated for scalar_t
+template <typename scalar_t>
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // call scalar_t specified routines
+    heevd_work_size_bytes(
+        jobz, uplo, n, dA, ldda, dW, dev_work_size, host_work_size, queue );
+}
+
+//==============================================================================
+// Specified scalar_t float -> syevd
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    // launch kernel
+    auto solver = queue.stream();
+    int lwork = dev_work_size / sizeof(float);
+    blas_dev_call(
+        oneapi::mkl::lapack::syevd(
+            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            dA, ldda, dW, (float*) dev_work, lwork ));
+
+    // default info returned
+    blas::device_memset( dev_info, 0, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+// Specified scalar_t double -> syevd
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    // launch kernel
+    auto solver = queue.stream();
+    int lwork = dev_work_size / sizeof(double);
+    blas_dev_call(
+        oneapi::mkl::lapack::syevd(
+            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            dA, ldda, dW, (double*) dev_work, lwork ));
+
+    // default info returned
+    blas::device_memset( dev_info, 0, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+// Specified scalar_t std::complex<float> -> heevd
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    // launch kernel
+    auto solver = queue.stream();
+    int lwork = dev_work_size / sizeof(std::complex<float>);
+    blas_dev_call(
+        oneapi::mkl::lapack::heevd(
+            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            dA, ldda, dW, (std::complex<float>*) dev_work, lwork ));
+
+    // default info returned
+    blas::device_memset( dev_info, 0, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+// Specified scalar_t std::complex<double> -> heevd
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    // launch kernel
+    auto solver = queue.stream();
+    int lwork = dev_work_size / sizeof(std::complex<double>);
+    blas_dev_call(
+        oneapi::mkl::lapack::heevd(
+            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            dA, ldda, dW, (std::complex<double>*) dev_work, lwork ));
+
+    // default info returned
+    blas::device_memset( dev_info, 0, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+// Templated for scalar_t.  This is an async call, the return info is
+// in dev_info on the device.
+// Currently dev_info is always set to default 0.
+template <typename scalar_t>
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    // call scalar_t specified routines
+    heevd(
+        jobz, uplo, n, dA, ldda, dW, dev_work, dev_work_size,
+        host_work, host_work_size, dev_info, queue );
+}
+
+//==============================================================================
+// Explicit instantiations.
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, float* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, double* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, std::complex<float>* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, std::complex<double>* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+//--------------------
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+} // namespace lapack
+
+#endif // LAPACK_HAVE_SYCL

--- a/src/onemkl/onemkl_heevd.cc
+++ b/src/onemkl/onemkl_heevd.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
@@ -23,7 +23,7 @@ oneapi::mkl::uplo uplo2onemkl(blas::Uplo uplo);
 //==============================================================================
 namespace lapack {
 
-//==============================================================================
+//------------------------------------------------------------------------------
 // Specified scalar_t float -> syevd
 void heevd_work_size_bytes(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -35,12 +35,12 @@ void heevd_work_size_bytes(
     auto solver = queue.stream();
     int lwork = 0;
     lwork = oneapi::mkl::lapack::syevd_scratchpad_size<float>(
-        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+        solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
     *dev_work_size = lwork * sizeof(float);
     *host_work_size = 0;
 }
 
-//------------------------------------------------------------------------------
+//----------
 // Specified scalar_t double -> syevd
 void heevd_work_size_bytes(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -52,12 +52,12 @@ void heevd_work_size_bytes(
     auto solver = queue.stream();
     int lwork = 0;
     lwork = oneapi::mkl::lapack::syevd_scratchpad_size<double>(
-        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+        solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
     *dev_work_size = lwork * sizeof(double);
     *host_work_size = 0;
 }
 
-//------------------------------------------------------------------------------
+//----------
 // Specified scalar_t std::complex<float> -> heevd
 void heevd_work_size_bytes(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -69,12 +69,12 @@ void heevd_work_size_bytes(
     auto solver = queue.stream();
     int lwork = 0;
     lwork = oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<float>>(
-        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+        solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
     *dev_work_size = lwork * sizeof(std::complex<float>);
     *host_work_size = 0;
 }
 
-//------------------------------------------------------------------------------
+//----------
 // Specified scalar_t std::complex<double> -> heevd
 void heevd_work_size_bytes(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -86,7 +86,7 @@ void heevd_work_size_bytes(
     auto solver = queue.stream();
     int lwork = 0;
     lwork = oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<double>>(
-        solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
+        solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n, ldda );
     *dev_work_size = lwork * sizeof(std::complex<double>);
     *host_work_size = 0;
 }
@@ -105,7 +105,7 @@ void heevd_work_size_bytes(
         jobz, uplo, n, dA, ldda, dW, dev_work_size, host_work_size, queue );
 }
 
-//==============================================================================
+//------------------------------------------------------------------------------
 // Specified scalar_t float -> syevd
 void heevd(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -119,14 +119,14 @@ void heevd(
     int lwork = dev_work_size / sizeof(float);
     blas_dev_call(
         oneapi::mkl::lapack::syevd(
-            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
             dA, ldda, dW, (float*) dev_work, lwork ));
 
     // default info returned
     blas::device_memset( dev_info, 0, 1, queue );
 }
 
-//------------------------------------------------------------------------------
+//----------
 // Specified scalar_t double -> syevd
 void heevd(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -140,14 +140,14 @@ void heevd(
     int lwork = dev_work_size / sizeof(double);
     blas_dev_call(
         oneapi::mkl::lapack::syevd(
-            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
             dA, ldda, dW, (double*) dev_work, lwork ));
 
     // default info returned
     blas::device_memset( dev_info, 0, 1, queue );
 }
 
-//------------------------------------------------------------------------------
+//----------
 // Specified scalar_t std::complex<float> -> heevd
 void heevd(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -161,14 +161,14 @@ void heevd(
     int lwork = dev_work_size / sizeof(std::complex<float>);
     blas_dev_call(
         oneapi::mkl::lapack::heevd(
-            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
             dA, ldda, dW, (std::complex<float>*) dev_work, lwork ));
 
     // default info returned
     blas::device_memset( dev_info, 0, 1, queue );
 }
 
-//------------------------------------------------------------------------------
+//----------
 // Specified scalar_t std::complex<double> -> heevd
 void heevd(
     lapack::Job jobz, lapack::Uplo uplo, int64_t n,
@@ -182,7 +182,7 @@ void heevd(
     int lwork = dev_work_size / sizeof(std::complex<double>);
     blas_dev_call(
         oneapi::mkl::lapack::heevd(
-            solver, jobz2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
+            solver, job2onemkl(jobz), blas::internal::uplo2onemkl(uplo), n,
             dA, ldda, dW, (std::complex<double>*) dev_work, lwork ));
 
     // default info returned
@@ -207,7 +207,7 @@ void heevd(
         host_work, host_work_size, dev_info, queue );
 }
 
-//==============================================================================
+//------------------------------------------------------------------------------
 // Explicit instantiations.
 template
 void heevd_work_size_bytes(

--- a/src/rocm/rocm_common.hh
+++ b/src/rocm/rocm_common.hh
@@ -17,4 +17,16 @@
     #include <rocsolver.h>
 #endif
 
+namespace lapack {
+
+// todo: Move to blaspp/src/onemkl_wrappers.cc as blas::internal::jobz2onemkl()?
+// should we call it job2evect_rocsolver ??
+inline const rocblas_evect  job2eigmode_rocsolver(lapack::Job jobz) {
+    if (jobz == lapack::Job::NoVec) return rocblas_evect_none;
+    if (jobz == lapack::Job::Vec) return rocblas_evect_original;
+    return rocblas_evect_none;
+}
+
+} // namespace lapack
+
 #endif // LAPACK_ROCM_COMMON_H

--- a/src/rocm/rocm_common.hh
+++ b/src/rocm/rocm_common.hh
@@ -19,7 +19,6 @@
 
 namespace lapack {
 
-// todo: Move to blaspp/src/onemkl_wrappers.cc as blas::internal::jobz2onemkl()?
 // should we call it job2evect_rocsolver ??
 inline const rocblas_evect  job2eigmode_rocsolver(lapack::Job jobz) {
     if (jobz == lapack::Job::NoVec) return rocblas_evect_none;

--- a/src/rocm/rocm_heevd.cc
+++ b/src/rocm/rocm_heevd.cc
@@ -1,0 +1,223 @@
+
+#include "lapack/defines.h"
+
+#if defined(LAPACK_HAVE_ROCBLAS)
+
+#include "rocm_common.hh"
+
+namespace blas {
+namespace internal {
+
+rocblas_fill uplo2rocblas(blas::Uplo uplo);
+
+}
+}
+
+
+//==============================================================================
+namespace lapack {
+
+//------------------------------------------------------------------------------
+// Specified scalar_t float -> syevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    *dev_work_size = n * sizeof(float);
+    *host_work_size = 0;
+}
+
+//----------
+// Specified scalar_t double -> dyevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    *dev_work_size = n * sizeof(double);
+    *host_work_size = 0;
+}
+
+//----------
+// Specified scalar_t std::complex<float> -> heevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    *dev_work_size = n * sizeof(std::complex<float>);
+    *host_work_size = 0;
+}
+
+//----------
+// Specified scalar_t std::complex<double> -> heevd
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // query for workspace size
+    auto solver = queue.stream();
+    *dev_work_size = n * sizeof(std::complex<double>);
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Templated for scalar_t
+template <typename scalar_t>
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    // call scalar_t specified routines
+    heevd_work_size_bytes(
+        jobz, uplo, n, dA, ldda, dW, dev_work_size, host_work_size, queue );
+}
+
+//------------------------------------------------------------------------------
+// Intermediate wrappers around rocSolver to deal with precisions.
+rocblas_status  rocsolver_heevd(
+    rocblas_handle solver, const rocblas_evect jobz,
+    const rocblas_fill uplo, rocblas_int n, float* dA,
+    const rocblas_int ldda, float* dW, float* dev_work, rocblas_int* info )
+{
+    return rocsolver_ssyevd(
+        solver, jobz, uplo, n, dA, ldda, dW, dev_work, info );
+}
+
+//----------
+rocblas_status  rocsolver_heevd(
+    rocblas_handle solver, const rocblas_evect jobz,
+    const rocblas_fill uplo, rocblas_int n, double* dA,
+    const rocblas_int ldda, double* dW, double* dev_work, rocblas_int* info )
+{
+    return rocsolver_dsyevd(
+        solver, jobz, uplo, n, dA, ldda, dW, dev_work, info );
+}
+
+//----------
+rocblas_status  rocsolver_heevd(
+    rocblas_handle solver, const rocblas_evect jobz,
+    const rocblas_fill uplo, rocblas_int n, std::complex<float>* dA,
+    const rocblas_int ldda, float* dW, float* dev_work, rocblas_int* info )
+{
+    return rocsolver_cheevd(
+        solver, jobz, uplo, n, (rocblas_float_complex*) dA, ldda,
+        dW, dev_work, info );
+}
+
+//----------
+rocblas_status  rocsolver_heevd(
+    rocblas_handle solver, const rocblas_evect jobz,
+    const rocblas_fill uplo, rocblas_int n, std::complex<double>* dA,
+    const rocblas_int ldda, double* dW, double* dev_work, rocblas_int* info )
+{
+    return rocsolver_zheevd(
+        solver, jobz, uplo, n, (rocblas_double_complex*) dA, ldda,
+        dW, dev_work, info );
+}
+
+//------------------------------------------------------------------------------
+// Wrapper around cuSolver.
+// This is async. Once finished, the return info is in dev_info on the device.
+template <typename scalar_t>
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    using real_t = blas::real_type<scalar_t>;
+    auto solver = queue.handle();
+
+    // for cuda, rocm, call set_device; for oneapi, do nothing.
+    blas::internal_set_device( queue.device() );
+
+    //int lwork = dev_work_size / sizeof(scalar_t);
+    blas_dev_call(
+        rocsolver_heevd(
+            solver, job2eigmode_rocsolver(jobz), blas::internal::uplo2rocblas(uplo), n, dA, ldda, dW,
+            (real_t*) dev_work, dev_info ));
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, float* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, double* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, std::complex<float>* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo,
+    int64_t n, std::complex<double>* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+//--------------------
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+} // namespace lapack
+
+#endif // LAPACK_HAVE_CUBLAS
+

--- a/src/rocm/rocm_heevd.cc
+++ b/src/rocm/rocm_heevd.cc
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include "lapack/defines.h"
 
@@ -5,69 +9,17 @@
 
 #include "rocm_common.hh"
 
+//==============================================================================
 namespace blas {
 namespace internal {
 
 rocblas_fill uplo2rocblas(blas::Uplo uplo);
 
-}
-}
-
+} // namespace internal
+} // namespace blas
 
 //==============================================================================
 namespace lapack {
-
-//------------------------------------------------------------------------------
-// Specified scalar_t float -> syevd
-void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
-    float* dA, int64_t ldda, float* dW,
-    size_t* dev_work_size, size_t* host_work_size,
-    lapack::Queue& queue )
-{
-    // query for workspace size
-    *dev_work_size = n * sizeof(float);
-    *host_work_size = 0;
-}
-
-//----------
-// Specified scalar_t double -> dyevd
-void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
-    double* dA, int64_t ldda, double* dW,
-    size_t* dev_work_size, size_t* host_work_size,
-    lapack::Queue& queue )
-{
-    // query for workspace size
-    *dev_work_size = n * sizeof(double);
-    *host_work_size = 0;
-}
-
-//----------
-// Specified scalar_t std::complex<float> -> heevd
-void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
-    std::complex<float>* dA, int64_t ldda, float* dW,
-    size_t* dev_work_size, size_t* host_work_size,
-    lapack::Queue& queue )
-{
-    // query for workspace size
-    *dev_work_size = n * sizeof(std::complex<float>);
-    *host_work_size = 0;
-}
-
-//----------
-// Specified scalar_t std::complex<double> -> heevd
-void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
-    std::complex<double>* dA, int64_t ldda, double* dW,
-    size_t* dev_work_size, size_t* host_work_size,
-    lapack::Queue& queue )
-{
-    // query for workspace size
-    *dev_work_size = n * sizeof(std::complex<double>);
-    *host_work_size = 0;
-}
 
 //------------------------------------------------------------------------------
 // Templated for scalar_t
@@ -78,9 +30,8 @@ void heevd_work_size_bytes(
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue )
 {
-    // call scalar_t specified routines
-    heevd_work_size_bytes(
-        jobz, uplo, n, dA, ldda, dW, dev_work_size, host_work_size, queue );
+    *dev_work_size = n * sizeof( scalar_t );
+    *host_work_size = 0;
 }
 
 //------------------------------------------------------------------------------
@@ -127,7 +78,7 @@ rocblas_status  rocsolver_heevd(
 }
 
 //------------------------------------------------------------------------------
-// Wrapper around cuSolver.
+// Wrapper around rocSolver.
 // This is async. Once finished, the return info is in dev_info on the device.
 template <typename scalar_t>
 void heevd(
@@ -143,7 +94,6 @@ void heevd(
     // for cuda, rocm, call set_device; for oneapi, do nothing.
     blas::internal_set_device( queue.device() );
 
-    //int lwork = dev_work_size / sizeof(scalar_t);
     blas_dev_call(
         rocsolver_heevd(
             solver, job2eigmode_rocsolver(jobz), blas::internal::uplo2rocblas(uplo), n, dA, ldda, dW,
@@ -215,5 +165,5 @@ void heevd(
 
 } // namespace lapack
 
-#endif // LAPACK_HAVE_CUBLAS
+#endif // LAPACK_HAVE_ROCBLAS
 

--- a/src/rocm/rocm_heevd.cc
+++ b/src/rocm/rocm_heevd.cc
@@ -26,7 +26,6 @@ void heevd_work_size_bytes(
     lapack::Queue& queue )
 {
     // query for workspace size
-    auto solver = queue.stream();
     *dev_work_size = n * sizeof(float);
     *host_work_size = 0;
 }
@@ -40,7 +39,6 @@ void heevd_work_size_bytes(
     lapack::Queue& queue )
 {
     // query for workspace size
-    auto solver = queue.stream();
     *dev_work_size = n * sizeof(double);
     *host_work_size = 0;
 }
@@ -54,7 +52,6 @@ void heevd_work_size_bytes(
     lapack::Queue& queue )
 {
     // query for workspace size
-    auto solver = queue.stream();
     *dev_work_size = n * sizeof(std::complex<float>);
     *host_work_size = 0;
 }
@@ -68,7 +65,6 @@ void heevd_work_size_bytes(
     lapack::Queue& queue )
 {
     // query for workspace size
-    auto solver = queue.stream();
     *dev_work_size = n * sizeof(std::complex<double>);
     *host_work_size = 0;
 }

--- a/src/stub/stub_heevd.cc
+++ b/src/stub/stub_heevd.cc
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include "lapack/defines.h"
 
@@ -14,7 +18,7 @@ namespace lapack {
 // dA is only for templating scalar_t; it isn't referenced.
 template <typename scalar_t>
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue )
@@ -41,28 +45,28 @@ void heevd(
 // Explicit instantiations.
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, float* dA, int64_t ldda, float* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );
 
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, double* dA, int64_t ldda, double* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );
 
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, std::complex<float>* dA, int64_t ldda, float* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );
 
 template
 void heevd_work_size_bytes(
-    lapack::Job jobz, lapack::Uplo uplo, 
+    lapack::Job jobz, lapack::Uplo uplo,
     int64_t n, std::complex<double>* dA, int64_t ldda, double* dW,
     size_t* dev_work_size, size_t* host_work_size,
     lapack::Queue& queue );

--- a/src/stub/stub_heevd.cc
+++ b/src/stub/stub_heevd.cc
@@ -1,0 +1,106 @@
+
+#include "lapack/defines.h"
+
+#if ! (defined(LAPACK_HAVE_ROCBLAS) || defined(LAPACK_HAVE_CUBLAS) || defined(LAPACK_HAVE_SYCL))
+
+#include "lapack/device.hh"
+
+
+//==============================================================================
+namespace lapack {
+
+//------------------------------------------------------------------------------
+// Wrapper around workspace query.
+// dA is only for templating scalar_t; it isn't referenced.
+template <typename scalar_t>
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue )
+{
+    *dev_work_size  = 0;
+    *host_work_size = 0;
+}
+
+//------------------------------------------------------------------------------
+// Wrapper stub.
+// This is async. Once finished, the return info is in dev_info on the device.
+template <typename scalar_t>
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    scalar_t* dA, int64_t ldda, blas::real_type<scalar_t>* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue )
+{
+    throw lapack::Error( "device LAPACK not available", __func__ );
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, float* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, double* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, std::complex<float>* dA, int64_t ldda, float* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+template
+void heevd_work_size_bytes(
+    lapack::Job jobz, lapack::Uplo uplo, 
+    int64_t n, std::complex<double>* dA, int64_t ldda, double* dW,
+    size_t* dev_work_size, size_t* host_work_size,
+    lapack::Queue& queue );
+
+//--------------------
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    float* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    double* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<float>* dA, int64_t ldda, float* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+template
+void heevd(
+    lapack::Job jobz, lapack::Uplo uplo, int64_t n,
+    std::complex<double>* dA, int64_t ldda, double* dW,
+    void*  dev_work, size_t  dev_work_size,
+    void* host_work, size_t host_work_size,
+    device_info_int* dev_info, lapack::Queue& queue );
+
+} // namespace lapack
+
+#endif // LAPACK_HAVE_CUBLAS
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,7 @@ add_executable(
     test_hecon.cc
     test_heev.cc
     test_heevd.cc
+    test_heevd_device.cc
     test_heevr.cc
     test_heevx.cc
     test_hegst.cc

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -622,6 +622,12 @@ if (opts.syev and opts.host):
     #[ 'ubmtr', gen + dtype_complex + la + mn + uplo + side + trans_nc ],
     ]
 
+if (opts.syev and opts.device):
+    # GPU
+    cmds += [
+    [ 'dev-heevd', gen + dtype + align + n + jobz + uplo ],
+    ]
+
 # generalized symmetric eigenvalues
 if (opts.sygv and opts.host):
     cmds += [

--- a/test/test.cc
+++ b/test/test.cc
@@ -461,6 +461,7 @@ std::vector< testsweeper::routines_t > routines = {
     { "dev-potrf",          test_potrf_device,  Section::gpu },
     { "dev-getrf",          test_getrf_device,  Section::gpu },
     { "dev-geqrf",          test_geqrf_device,  Section::gpu },
+    { "dev-heevd",          test_heevd_device,  Section::gpu },
     { "",                   nullptr,            Section::newline },
 };
 

--- a/test/test.hh
+++ b/test/test.hh
@@ -469,5 +469,6 @@ void test_symv  ( Params& params, bool run );
 void test_potrf_device ( Params& params, bool run );
 void test_getrf_device ( Params& params, bool run );
 void test_geqrf_device ( Params& params, bool run );
+void test_heevd_device ( Params& params, bool run );
 
 #endif  //  #ifndef TEST_HH

--- a/test/test_heevd_device.cc
+++ b/test/test_heevd_device.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
@@ -72,8 +73,8 @@ void test_heevd_device_work( Params& params, bool run )
 
     // Allocate workspace
     size_t d_size, h_size;
-    lapack::heevd_work_size_bytes( jobz, uplo, n, dA_tst, lda, dW_tst, 
-      &d_size, &h_size, queue );
+    lapack::heevd_work_size_bytes( jobz, uplo, n, dA_tst, lda, dW_tst,
+                                   &d_size, &h_size, queue );
     char* d_work = blas::device_malloc< char >( d_size, queue );
     std::vector<char> h_work_vector( h_size );
     char* h_work = h_work_vector.data();
@@ -93,7 +94,7 @@ void test_heevd_device_work( Params& params, bool run )
     double time = testsweeper::get_wtime();
 
     lapack::heevd( jobz, uplo, n, dA_tst, lda, dW_tst, d_work, d_size,
-      h_work, h_size, d_info, queue );
+                   h_work, h_size, d_info, queue );
 
     queue.sync();
     time = testsweeper::get_wtime() - time;
@@ -105,7 +106,7 @@ void test_heevd_device_work( Params& params, bool run )
     // Copy result back to CPU.
     device_info_int info_tst;
     blas::device_copy_matrix( n, n, dA_tst, lda, Z.data(), ldz, queue );
-    blas::device_copy_matrix( n, 1, dW_tst, n,   Lambda_tst.data(), n, queue );
+    blas::device_copy_vector( n, dW_tst, 1, Lambda_tst.data(), 1, queue );
     blas::device_memcpy( &info_tst, d_info, 1, queue );
     queue.sync();
 

--- a/test/test_heevd_device.cc
+++ b/test/test_heevd_device.cc
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "lapack.hh"
+#include "scale.hh"
+#include "lapack/device.hh"
+#include "lapack/flops.hh"
+#include "print_matrix.hh"
+#include "error.hh"
+#include "lapacke_wrappers.hh"
+
+#include <vector>
+
+template< typename scalar_t >
+void test_heevd_device_work( Params& params, bool run )
+{
+    using lapack::device_info_int;
+    using real_t = blas::real_type< scalar_t >;
+
+    // Constants
+    const scalar_t one  = 1.0;
+    const real_t   eps  = std::numeric_limits< real_t >::epsilon();
+
+    // get & mark input values
+    lapack::Job jobz = params.jobz();
+    lapack::Uplo uplo = params.uplo();
+    int64_t n = params.dim.n();
+    int64_t device = params.device();
+    int64_t align = params.align();
+    int64_t verbose = params.verbose();
+    real_t tol = params.tol() * eps;
+    params.matrix.mark();
+
+    // mark non-standard output values
+    params.ref_time();
+    // params.ref_gflops();
+    // params.gflops();
+    params.error2();
+
+    if (! run)
+        return;
+
+    if (blas::get_device_count() == 0) {
+        params.msg() = "skipping: no GPU devices or no GPU support";
+        return;
+    }
+
+    // ---------- setup
+    int64_t lda = roundup( blas::max( 1, n ), align );
+    int64_t ldz = lda;  // vectors overwrite matrix A
+    size_t size_A = (size_t) lda * n;
+    size_t size_Z = size_A;
+    size_t size_W = (size_t) n;
+
+    std::vector< scalar_t > A( size_A );
+    std::vector< scalar_t > Z( size_Z );  // eigenvectors
+    std::vector< real_t > Lambda_tst( n );
+    std::vector< real_t > Lambda_ref( n );
+
+    lapack::generate_matrix( params.matrix, n, n, &A[0], lda );
+    Z = A;
+
+    // Allocate and copy to GPU
+    lapack::Queue queue( device );
+    scalar_t*        dA_tst = blas::device_malloc< scalar_t >( size_A, queue );
+    real_t*          dW_tst = blas::device_malloc< real_t >  ( size_W, queue );
+    device_info_int* d_info = blas::device_malloc< device_info_int >( 1, queue );
+    blas::device_copy_matrix( n, n, A.data(), lda, dA_tst, lda, queue );
+
+
+    // Allocate workspace
+    size_t d_size, h_size;
+    lapack::heevd_work_size_bytes( jobz, uplo, n, dA_tst, lda, dW_tst, 
+      &d_size, &h_size, queue );
+    char* d_work = blas::device_malloc< char >( d_size, queue );
+    std::vector<char> h_work_vector( h_size );
+    char* h_work = h_work_vector.data();
+
+
+    if (verbose >= 1) {
+        printf( "\n" );
+        printf( "A n=%5lld, lda=%5lld\n", llong( n ), llong( lda ) );
+    }
+    if (verbose >= 2) {
+        printf( "A = " ); print_matrix( n, n, &A[0], lda );
+    }
+
+    // ---------- run test
+    testsweeper::flush_cache( params.cache() );
+    queue.sync();
+    double time = testsweeper::get_wtime();
+
+    lapack::heevd( jobz, uplo, n, dA_tst, lda, dW_tst, d_work, d_size,
+      h_work, h_size, d_info, queue );
+
+    queue.sync();
+    time = testsweeper::get_wtime() - time;
+
+    params.time() = time;
+    // double gflop = lapack::Gflop< scalar_t >::heev( jobz, n );
+    // params.gflops() = gflop / time;
+
+    // Copy result back to CPU.
+    device_info_int info_tst;
+    blas::device_copy_matrix( n, n, dA_tst, lda, Z.data(), ldz, queue );
+    blas::device_copy_matrix( n, 1, dW_tst, n,   Lambda_tst.data(), n, queue );
+    blas::device_memcpy( &info_tst, d_info, 1, queue );
+    queue.sync();
+
+
+    if (info_tst != 0) {
+        fprintf( stderr, "lapack::heev returned error %lld\n", llong( info_tst ) );
+    }
+
+    // Cleanup GPU memory
+    blas::device_free( dA_tst, queue );
+    blas::device_free( dW_tst, queue );
+    blas::device_free( d_work, queue );
+    blas::device_free( d_info, queue );
+
+    if (verbose >= 2) {
+        printf( "Z = " ); print_matrix( n, n, &Z[0], ldz );
+        printf( "Lambda = " ); print_vector( n, &Lambda_tst[0], 1 );
+    }
+
+    if (params.check() == 'y' && jobz == lapack::Job::Vec) {
+        // ---------- check error
+        // Relative backwards error =
+        //     ||A Z - Z Lambda|| / (n * ||A|| * ||Z||)
+        real_t Anorm = lapack::lanhe( lapack::Norm::One, uplo, n, &A[0], lda );
+        real_t Znorm = lapack::lange( lapack::Norm::One, n, n, &Z[0], ldz );
+
+        std::vector< scalar_t > W( size_Z );  // workspace
+        int64_t ldw = ldz;
+        // W = Z
+        lapack::lacpy( lapack::MatrixType::General, n, n,
+                       &Z[0], ldz,
+                       &W[0], ldw );
+        // W = Z Lambda
+        col_scale( n, n, &W[0], ldw, &Lambda_tst[0] );
+        // W = A Z - (Z Lambda)
+        blas::hemm( blas::Layout::ColMajor, blas::Side::Left, uplo, n, n,
+                    one,  &A[0], lda,
+                          &Z[0], ldz,
+                    -one, &W[0], ldw );
+        real_t error = lapack::lange( lapack::Norm::One, n, n, &W[0], ldw );
+        if (verbose >= 2) {
+            printf( "W = " ); print_matrix( n, n, &W[0], ldw );
+        }
+
+        error /= (n * Anorm * Znorm);
+        params.error() = error;
+        params.okay() = (error < tol);
+    }
+
+    if (params.ref() == 'y' || params.check() == 'y') {
+        // ---------- run reference
+        testsweeper::flush_cache( params.cache() );
+        time = testsweeper::get_wtime();
+        int64_t info_ref = LAPACKE_heev(
+            job2char(jobz), uplo2char(uplo), n,
+            &A[0], lda, &Lambda_ref[0] );
+        time = testsweeper::get_wtime() - time;
+        if (info_ref != 0) {
+            fprintf( stderr, "LAPACKE_heev returned error %lld\n", llong( info_ref ) );
+        }
+
+        params.ref_time() = time;
+        // params.ref_gflops() = gflop / time;
+
+        // ---------- check error compared to reference
+        real_t error = rel_error( Lambda_tst, Lambda_ref );
+        if (info_tst != info_ref) {
+            error = 1;
+        }
+        params.error2() = error;
+        params.okay() = params.okay() && (error < tol);
+    }
+}
+
+// -----------------------------------------------------------------------------
+void test_heevd_device( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Integer:
+            throw std::exception();
+            break;
+
+        case testsweeper::DataType::Single:
+            test_heevd_device_work< float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_heevd_device_work< double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_heevd_device_work< std::complex<float> >( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_heevd_device_work< std::complex<double> >( params, run );
+            break;
+    }
+}


### PR DESCRIPTION
This change was required for tighter integration with NWChemEx.

Adds the following:
- [x] Device API for `heevd`
- [x] `cuSolver` implementation of `heevd`
- [x] `rocSolver` implementation of `heevd`
- [x] Device stubs for `heevd`
- [x] Unit test for device `heevd`

Opening early to coordinate if necessary.  I have access to OLCF to add `rocSolver`, but I'd have to update my credentials with ALCF to get access to Intel/oneMKL HW. Also, I do not have access to a pre-11 CUDA installation, so the path for manual dispatch is untested. Unit tests on NVIDIA work locally and at NERSC

```
$ nvidia-smi
Fri Aug 25 16:27:53 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 515.105.01   Driver Version: 515.105.01   CUDA Version: 11.7     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA RTX A5000    On   | 00000000:81:00.0 Off |                  Off |
| 30%   34C    P8    20W / 230W |     73MiB / 24564MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
```

```
$ ./tester  --type s,d,c,z --align 32 --dim 100:500:100 --jobz n,v --uplo l,u dev-heevd
LAPACK++ version 2023.06.00, id 082daf3
input: ./tester --type 's,d,c,z' --align 32 --dim '100:500:100' --jobz 'n,v' --uplo 'l,u' dev-heevd
                                                                                                 
type    uplo   jobz       n  align  device     error    error2   time (s)  ref time (s)  status  
test matrix A: rand, cond(S) = NA
   s   lower  novec     100     32       0        NA  3.11e-07   0.000832       0.00338  pass    
   s   lower  novec     200     32       0        NA  5.21e-07    0.00163       0.00887  pass    
   s   lower  novec     300     32       0        NA  5.03e-07    0.00258        0.0185  pass    
   s   lower  novec     400     32       0        NA  6.54e-07    0.00343        0.0172  pass    
   s   lower  novec     500     32       0        NA  5.67e-07    0.00433        0.0236  pass    
   s   lower    vec     100     32       0  5.33e-09  5.56e-07    0.00135        0.0114  pass    
   s   lower    vec     200     32       0  1.66e-09  4.06e-07    0.00196        0.0825  pass    
   s   lower    vec     300     32       0  2.07e-09  1.15e-06    0.00308         0.182  pass    
   s   lower    vec     400     32       0  1.64e-09  4.22e-07    0.00414         0.364  pass    
   s   lower    vec     500     32       0  1.33e-09  9.87e-07    0.00522         0.668  pass    
   s   upper  novec     100     32       0        NA  3.53e-07   0.000774      0.000851  pass    
   s   upper  novec     200     32       0        NA  6.53e-07    0.00164       0.00292  pass    
   s   upper  novec     300     32       0        NA  5.33e-07    0.00263        0.0265  pass    
   s   upper  novec     400     32       0        NA  5.33e-07    0.00348        0.0160  pass    
   s   upper  novec     500     32       0        NA  4.97e-07    0.00432        0.0255  pass    
   s   upper    vec     100     32       0  3.33e-09  3.11e-07    0.00698        0.0140  pass    
   s   upper    vec     200     32       0  2.07e-09  5.25e-07    0.00199        0.0695  pass    
   s   upper    vec     300     32       0  1.80e-09  1.15e-06    0.00323         0.179  pass    
   s   upper    vec     400     32       0  1.67e-09  4.51e-07    0.00418         0.364  pass    
   s   upper    vec     500     32       0  1.36e-09  5.80e-07    0.00526         0.666  pass    

   d   lower  novec     100     32       0        NA  7.81e-16    0.00378       0.00115  pass    
   d   lower  novec     200     32       0        NA  1.93e-15    0.00637       0.00603  pass    
   d   lower  novec     300     32       0        NA  1.17e-15    0.00941        0.0205  pass    
   d   lower  novec     400     32       0        NA  1.23e-15     0.0118        0.0377  pass    
   d   lower  novec     500     32       0        NA  1.52e-15     0.0162        0.0329  pass    
   d   lower    vec     100     32       0  9.08e-18  1.09e-15     0.0102        0.0209  pass    
   d   lower    vec     200     32       0  3.55e-18  1.70e-15    0.00709         0.106  pass    
   d   lower    vec     300     32       0  3.24e-18  1.09e-15     0.0106         0.219  pass    
   d   lower    vec     400     32       0  3.29e-18  9.95e-16     0.0139         0.420  pass    
   d   lower    vec     500     32       0  9.21e-19  1.04e-15     0.0173         0.771  pass    
   d   upper  novec     100     32       0        NA  8.21e-16    0.00376      0.000935  pass    
   d   upper  novec     200     32       0        NA  8.95e-16    0.00645       0.00356  pass    
   d   upper  novec     300     32       0        NA  1.03e-15    0.00944        0.0270  pass    
   d   upper  novec     400     32       0        NA  1.59e-15     0.0122        0.0217  pass    
   d   upper  novec     500     32       0        NA  9.22e-16     0.0143        0.0307  pass    
   d   upper    vec     100     32       0  2.23e-18  6.53e-16    0.00844        0.0312  pass    
   d   upper    vec     200     32       0  2.18e-18  9.50e-16    0.00719        0.0688  pass    
   d   upper    vec     300     32       0  3.46e-18  1.00e-15     0.0111         0.202  pass    
   d   upper    vec     400     32       0  1.28e-18  1.43e-15     0.0142         0.447  pass    
   d   upper    vec     500     32       0  8.42e-19  1.20e-15     0.0173         0.800  pass    

   c   lower  novec     100     32       0        NA  2.55e-07   0.000909       0.00151  pass    
   c   lower  novec     200     32       0        NA  4.40e-07    0.00182       0.00554  pass    
   c   lower  novec     300     32       0        NA  6.52e-07    0.00707        0.0362  pass    
   c   lower  novec     400     32       0        NA  7.08e-07    0.00380        0.0503  pass    
   c   lower  novec     500     32       0        NA  5.64e-07    0.00478        0.0610  pass    
   c   lower    vec     100     32       0  4.91e-09  3.61e-07    0.00152        0.0237  pass    
   c   lower    vec     200     32       0  2.86e-09  4.47e-07    0.00220         0.123  pass    
   c   lower    vec     300     32       0  1.46e-09  1.26e-06    0.00347         0.293  pass    
   c   lower    vec     400     32       0  1.67e-09  6.48e-07    0.00460         0.621  pass    
   c   lower    vec     500     32       0  1.31e-09  7.96e-07    0.00586         1.159  pass    
   c   upper  novec     100     32       0        NA  3.17e-07   0.000943       0.00125  pass    
   c   upper  novec     200     32       0        NA  4.96e-07    0.00187        0.0242  pass    
   c   upper  novec     300     32       0        NA  7.21e-07    0.00292        0.0158  pass    
   c   upper  novec     400     32       0        NA  5.97e-07    0.00387        0.0801  pass    
   c   upper  novec     500     32       0        NA  6.24e-07    0.00479        0.0693  pass    
   c   upper    vec     100     32       0  1.28e-09  2.53e-07    0.00154        0.0376  pass    
   c   upper    vec     200     32       0  1.10e-09  6.28e-07    0.00221         0.134  pass    
   c   upper    vec     300     32       0  1.64e-09  4.91e-07    0.00355         0.247  pass    
   c   upper    vec     400     32       0  1.05e-09  5.14e-07    0.00466         0.576  pass    
   c   upper    vec     500     32       0  1.30e-09  4.67e-07    0.00587         1.084  pass    

   z   lower  novec     100     32       0        NA  1.07e-15    0.00409       0.00165  pass    
   z   lower  novec     200     32       0        NA  1.23e-15    0.00801        0.0240  pass    
   z   lower  novec     300     32       0        NA  1.29e-15     0.0126        0.0391  pass    
   z   lower  novec     400     32       0        NA  1.36e-15     0.0170        0.0479  pass    
   z   lower  novec     500     32       0        NA  1.47e-15     0.0218        0.0553  pass    
   z   lower    vec     100     32       0  1.04e-17  5.77e-16    0.00560        0.0407  pass    
   z   lower    vec     200     32       0  4.95e-18  9.64e-16     0.0127         0.154  pass    
   z   lower    vec     300     32       0  3.53e-18  1.02e-15     0.0157         0.365  pass    
   z   lower    vec     400     32       0  2.22e-18  1.04e-15     0.0219         0.786  pass    
   z   lower    vec     500     32       0  1.53e-18  1.15e-15     0.0290         1.451  pass    
   z   upper  novec     100     32       0        NA  4.35e-16    0.00406       0.00148  pass    
   z   upper  novec     200     32       0        NA  1.16e-15    0.00805       0.00836  pass    
   z   upper  novec     300     32       0        NA  1.18e-15     0.0128        0.0249  pass    
   z   upper  novec     400     32       0        NA  8.89e-16     0.0172        0.0389  pass    
   z   upper  novec     500     32       0        NA  1.28e-15     0.0219        0.0540  pass    
   z   upper    vec     100     32       0  3.08e-18  7.00e-16    0.00569        0.0353  pass    
   z   upper    vec     200     32       0  5.35e-18  1.00e-15    0.00974         0.161  pass    
   z   upper    vec     300     32       0  2.13e-18  1.90e-15     0.0161         0.389  pass    
   z   upper    vec     400     32       0  8.77e-19  8.53e-16     0.0224         0.778  pass    
   z   upper    vec     500     32       0  2.03e-18  1.18e-15     0.0288         1.445  pass    
All tests passed for dev-heevd.
```