### PR TITLE
Fix compilation issue since testsweeper now has half-precision datatype

### DIFF
--- a/test/test_gbcon.cc
+++ b/test/test_gbcon.cc
@@ -100,10 +100,6 @@ void test_gbcon_work( Params& params, bool run )
 void test_gbcon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbcon_work< float >( params, run );
             break;
@@ -118,6 +114,10 @@ void test_gbcon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gbcon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbequ.cc
+++ b/test/test_gbequ.cc
@@ -100,10 +100,6 @@ void test_gbequ_work( Params& params, bool run )
 void test_gbequ( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbequ_work< float >( params, run );
             break;
@@ -118,6 +114,10 @@ void test_gbequ( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gbequ_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbrfs.cc
+++ b/test/test_gbrfs.cc
@@ -181,10 +181,6 @@ void test_gbrfs_work( Params& params, bool run )
 void test_gbrfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbrfs_work< float >( params, run );
             break;
@@ -199,6 +195,10 @@ void test_gbrfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gbrfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbsv.cc
+++ b/test/test_gbsv.cc
@@ -134,10 +134,6 @@ void test_gbsv_work( Params& params, bool run )
 void test_gbsv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbsv_work< float >( params, run );
             break;
@@ -152,6 +148,10 @@ void test_gbsv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gbsv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbtrf.cc
+++ b/test/test_gbtrf.cc
@@ -90,10 +90,6 @@ void test_gbtrf_work( Params& params, bool run )
 void test_gbtrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbtrf_work< float >( params, run );
             break;
@@ -108,6 +104,10 @@ void test_gbtrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gbtrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbtrs.cc
+++ b/test/test_gbtrs.cc
@@ -143,10 +143,6 @@ void test_gbtrs_work( Params& params, bool run )
 void test_gbtrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbtrs_work< float >( params, run );
             break;
@@ -161,6 +157,10 @@ void test_gbtrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gbtrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gecon.cc
+++ b/test/test_gecon.cc
@@ -86,10 +86,6 @@ void test_gecon_work( Params& params, bool run )
 void test_gecon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gecon_work< float >( params, run );
             break;
@@ -104,6 +100,10 @@ void test_gecon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gecon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_geequ.cc
+++ b/test/test_geequ.cc
@@ -97,10 +97,6 @@ void test_geequ_work( Params& params, bool run )
 void test_geequ( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_geequ_work< float >( params, run );
             break;
@@ -115,6 +111,10 @@ void test_geequ( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_geequ_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_geev.cc
+++ b/test/test_geev.cc
@@ -192,10 +192,6 @@ void test_geev_work( Params& params, bool run )
 void test_geev( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_geev_work< float >( params, run );
             break;
@@ -210,6 +206,10 @@ void test_geev( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_geev_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gehrd.cc
+++ b/test/test_gehrd.cc
@@ -95,10 +95,6 @@ void test_gehrd_work( Params& params, bool run )
 void test_gehrd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gehrd_work< float >( params, run );
             break;
@@ -113,6 +109,10 @@ void test_gehrd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gehrd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gelqf.cc
+++ b/test/test_gelqf.cc
@@ -134,10 +134,6 @@ void test_gelqf_work( Params& params, bool run )
 void test_gelqf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gelqf_work< float >( params, run );
             break;
@@ -152,6 +148,10 @@ void test_gelqf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gelqf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -102,10 +102,6 @@ void test_gels_work( Params& params, bool run )
 void test_gels( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gels_work< float >( params, run );
             break;
@@ -120,6 +116,10 @@ void test_gels( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gels_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gelsd.cc
+++ b/test/test_gelsd.cc
@@ -108,10 +108,6 @@ void test_gelsd_work( Params& params, bool run )
 void test_gelsd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gelsd_work< float >( params, run );
             break;
@@ -126,6 +122,10 @@ void test_gelsd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gelsd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gelss.cc
+++ b/test/test_gelss.cc
@@ -108,10 +108,6 @@ void test_gelss_work( Params& params, bool run )
 void test_gelss( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gelss_work< float >( params, run );
             break;
@@ -126,6 +122,10 @@ void test_gelss( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gelss_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gelsy.cc
+++ b/test/test_gelsy.cc
@@ -112,10 +112,6 @@ void test_gelsy_work( Params& params, bool run )
 void test_gelsy( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gelsy_work< float >( params, run );
             break;
@@ -130,6 +126,10 @@ void test_gelsy( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gelsy_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gemqrt.cc
+++ b/test/test_gemqrt.cc
@@ -118,10 +118,6 @@ void test_gemqrt( Params& params, bool run )
 {
 #if LAPACK_VERSION >= 30400  // >= 3.4.0
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gemqrt_work< float >( params, run );
             break;
@@ -136,6 +132,10 @@ void test_gemqrt( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gemqrt_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 #else

--- a/test/test_geqlf.cc
+++ b/test/test_geqlf.cc
@@ -142,10 +142,6 @@ void test_geqlf_work( Params& params, bool run )
 void test_geqlf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_geqlf_work< float >( params, run );
             break;
@@ -160,6 +156,10 @@ void test_geqlf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_geqlf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_geqr.cc
+++ b/test/test_geqr.cc
@@ -98,10 +98,6 @@ void test_geqr_work( Params& params, bool run )
 void test_geqr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_geqr_work< float >( params, run );
             break;
@@ -116,6 +112,10 @@ void test_geqr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_geqr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_geqrf.cc
+++ b/test/test_geqrf.cc
@@ -132,10 +132,6 @@ void test_geqrf_work( Params& params, bool run )
 void test_geqrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_geqrf_work< float >( params, run );
             break;
@@ -150,6 +146,10 @@ void test_geqrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_geqrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_geqrf_device.cc
+++ b/test/test_geqrf_device.cc
@@ -216,7 +216,7 @@ void test_geqrf_device( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gerfs.cc
+++ b/test/test_gerfs.cc
@@ -123,10 +123,6 @@ void test_gerfs_work( Params& params, bool run )
 void test_gerfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gerfs_work< float >( params, run );
             break;
@@ -141,6 +137,10 @@ void test_gerfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gerfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gerqf.cc
+++ b/test/test_gerqf.cc
@@ -149,10 +149,6 @@ void test_gerqf_work( Params& params, bool run )
 void test_gerqf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gerqf_work< float >( params, run );
             break;
@@ -167,6 +163,10 @@ void test_gerqf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gerqf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gesdd.cc
+++ b/test/test_gesdd.cc
@@ -140,10 +140,6 @@ void test_gesdd_work( Params& params, bool run )
 void test_gesdd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gesdd_work< float >( params, run );
             break;
@@ -158,6 +154,10 @@ void test_gesdd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gesdd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -154,10 +154,6 @@ void test_gesv_work( Params& params, bool run )
 void test_gesv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gesv_work< float >( params, run );
             break;
@@ -172,6 +168,10 @@ void test_gesv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gesv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gesvd.cc
+++ b/test/test_gesvd.cc
@@ -168,10 +168,6 @@ void test_gesvd_work( Params& params, bool run )
 void test_gesvd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gesvd_work< float >( params, run );
             break;
@@ -186,6 +182,10 @@ void test_gesvd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gesvd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gesvdx.cc
+++ b/test/test_gesvdx.cc
@@ -119,10 +119,6 @@ void test_gesvdx_work( Params& params, bool run )
 void test_gesvdx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gesvdx_work< float >( params, run );
             break;
@@ -137,6 +133,10 @@ void test_gesvdx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gesvdx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gesvx.cc
+++ b/test/test_gesvx.cc
@@ -172,10 +172,6 @@ void test_gesvx_work( Params& params, bool run )
 void test_gesvx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gesvx_work< float >( params, run );
             break;
@@ -190,6 +186,10 @@ void test_gesvx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gesvx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_getrf.cc
+++ b/test/test_getrf.cc
@@ -142,10 +142,6 @@ void test_getrf_work( Params& params, bool run )
 void test_getrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_getrf_work< float >( params, run );
             break;
@@ -160,6 +156,10 @@ void test_getrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_getrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_getrf_device.cc
+++ b/test/test_getrf_device.cc
@@ -209,7 +209,7 @@ void test_getrf_device( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_getri.cc
+++ b/test/test_getri.cc
@@ -147,10 +147,6 @@ void test_getri_work( Params& params, bool run )
 void test_getri( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_getri_work< float >( params, run );
             break;
@@ -165,6 +161,10 @@ void test_getri( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_getri_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_getrs.cc
+++ b/test/test_getrs.cc
@@ -128,10 +128,6 @@ void test_getrs_work( Params& params, bool run )
 void test_getrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_getrs_work< float >( params, run );
             break;
@@ -146,6 +142,10 @@ void test_getrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_getrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_getsls.cc
+++ b/test/test_getsls.cc
@@ -105,10 +105,6 @@ void test_getsls_work( Params& params, bool run )
 void test_getsls( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_getsls_work< float >( params, run );
             break;
@@ -123,6 +119,10 @@ void test_getsls( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_getsls_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ggev.cc
+++ b/test/test_ggev.cc
@@ -113,10 +113,6 @@ void test_ggev_work( Params& params, bool run )
 void test_ggev( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ggev_work< float >( params, run );
             break;
@@ -131,6 +127,10 @@ void test_ggev( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ggev_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ggglm.cc
+++ b/test/test_ggglm.cc
@@ -119,10 +119,6 @@ void test_ggglm_work( Params& params, bool run )
 void test_ggglm( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ggglm_work< float >( params, run );
             break;
@@ -137,6 +133,10 @@ void test_ggglm( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ggglm_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gglse.cc
+++ b/test/test_gglse.cc
@@ -186,10 +186,6 @@ void test_gglse_work( Params& params, bool run )
 void test_gglse( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gglse_work< float >( params, run );
             break;
@@ -204,6 +200,10 @@ void test_gglse( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gglse_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ggqrf.cc
+++ b/test/test_ggqrf.cc
@@ -101,10 +101,6 @@ void test_ggqrf_work( Params& params, bool run )
 void test_ggqrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ggqrf_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_ggqrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ggqrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ggrqf.cc
+++ b/test/test_ggrqf.cc
@@ -101,10 +101,6 @@ void test_ggrqf_work( Params& params, bool run )
 void test_ggrqf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ggrqf_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_ggrqf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ggrqf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gtcon.cc
+++ b/test/test_gtcon.cc
@@ -107,10 +107,6 @@ void test_gtcon_work( Params& params, bool run )
 void test_gtcon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gtcon_work< float >( params, run );
             break;
@@ -125,6 +121,10 @@ void test_gtcon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gtcon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gtrfs.cc
+++ b/test/test_gtrfs.cc
@@ -140,10 +140,6 @@ void test_gtrfs_work( Params& params, bool run )
 void test_gtrfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gtrfs_work< float >( params, run );
             break;
@@ -158,6 +154,10 @@ void test_gtrfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gtrfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gtsv.cc
+++ b/test/test_gtsv.cc
@@ -102,10 +102,6 @@ void test_gtsv_work( Params& params, bool run )
 void test_gtsv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gtsv_work< float >( params, run );
             break;
@@ -120,6 +116,10 @@ void test_gtsv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gtsv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gttrf.cc
+++ b/test/test_gttrf.cc
@@ -101,10 +101,6 @@ void test_gttrf_work( Params& params, bool run )
 void test_gttrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gttrf_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_gttrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gttrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gttrs.cc
+++ b/test/test_gttrs.cc
@@ -108,10 +108,6 @@ void test_gttrs_work( Params& params, bool run )
 void test_gttrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gttrs_work< float >( params, run );
             break;
@@ -126,6 +122,10 @@ void test_gttrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_gttrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbev.cc
+++ b/test/test_hbev.cc
@@ -163,10 +163,6 @@ void test_hbev_work( Params& params, bool run )
 void test_hbev( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbev_work< float >( params, run );
             break;
@@ -181,6 +177,10 @@ void test_hbev( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hbev_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbevd.cc
+++ b/test/test_hbevd.cc
@@ -162,10 +162,6 @@ void test_hbevd_work( Params& params, bool run )
 void test_hbevd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbevd_work< float >( params, run );
             break;
@@ -180,6 +176,10 @@ void test_hbevd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hbevd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbevx.cc
+++ b/test/test_hbevx.cc
@@ -190,10 +190,6 @@ void test_hbevx_work( Params& params, bool run )
 void test_hbevx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbevx_work< float >( params, run );
             break;
@@ -208,6 +204,10 @@ void test_hbevx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hbevx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbgv.cc
+++ b/test/test_hbgv.cc
@@ -201,10 +201,6 @@ void test_hbgv_work( Params& params, bool run )
 void test_hbgv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbgv_work< float >( params, run );
             break;
@@ -219,6 +215,10 @@ void test_hbgv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hbgv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbgvd.cc
+++ b/test/test_hbgvd.cc
@@ -203,10 +203,6 @@ void test_hbgvd_work( Params& params, bool run )
 void test_hbgvd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbgvd_work< float >( params, run );
             break;
@@ -221,6 +217,10 @@ void test_hbgvd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hbgvd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbgvx.cc
+++ b/test/test_hbgvx.cc
@@ -226,10 +226,6 @@ void test_hbgvx_work( Params& params, bool run )
 void test_hbgvx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbgvx_work< float >( params, run );
             break;
@@ -244,6 +240,10 @@ void test_hbgvx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hbgvx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hecon.cc
+++ b/test/test_hecon.cc
@@ -97,10 +97,6 @@ void test_hecon_work( Params& params, bool run )
 void test_hecon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hecon_work< float >( params, run );
             break;
@@ -115,6 +111,10 @@ void test_hecon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hecon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -141,10 +141,6 @@ void test_heev_work( Params& params, bool run )
 void test_heev( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_heev_work< float >( params, run );
             break;
@@ -159,6 +155,10 @@ void test_heev( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_heev_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_heevd.cc
+++ b/test/test_heevd.cc
@@ -141,10 +141,6 @@ void test_heevd_work( Params& params, bool run )
 void test_heevd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_heevd_work< float >( params, run );
             break;
@@ -159,6 +155,10 @@ void test_heevd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_heevd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_heevd_device.cc
+++ b/test/test_heevd_device.cc
@@ -185,10 +185,6 @@ void test_heevd_device_work( Params& params, bool run )
 void test_heevd_device( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_heevd_device_work< float >( params, run );
             break;
@@ -203,6 +199,10 @@ void test_heevd_device( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_heevd_device_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_heevr.cc
+++ b/test/test_heevr.cc
@@ -177,10 +177,6 @@ void test_heevr_work( Params& params, bool run )
 void test_heevr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_heevr_work< float >( params, run );
             break;
@@ -195,6 +191,10 @@ void test_heevr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_heevr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_heevx.cc
+++ b/test/test_heevx.cc
@@ -185,10 +185,6 @@ void test_heevx_work( Params& params, bool run )
 void test_heevx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_heevx_work< float >( params, run );
             break;
@@ -203,6 +199,10 @@ void test_heevx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_heevx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hegst.cc
+++ b/test/test_hegst.cc
@@ -121,10 +121,6 @@ void test_hegst_work( Params& params, bool run )
 void test_hegst( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hegst_work< float >( params, run );
             break;
@@ -139,6 +135,10 @@ void test_hegst( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hegst_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hegv.cc
+++ b/test/test_hegv.cc
@@ -215,10 +215,6 @@ void test_hegv_work( Params& params, bool run )
 void test_hegv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hegv_work< float >( params, run );
             break;
@@ -233,6 +229,10 @@ void test_hegv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hegv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hegvd.cc
+++ b/test/test_hegvd.cc
@@ -215,10 +215,6 @@ void test_hegvd_work( Params& params, bool run )
 void test_hegvd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hegvd_work< float >( params, run );
             break;
@@ -233,6 +229,10 @@ void test_hegvd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hegvd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hegvx.cc
+++ b/test/test_hegvx.cc
@@ -239,10 +239,6 @@ void test_hegvx_work( Params& params, bool run )
 void test_hegvx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hegvx_work< float >( params, run );
             break;
@@ -257,6 +253,10 @@ void test_hegvx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hegvx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_herfs.cc
+++ b/test/test_herfs.cc
@@ -125,10 +125,6 @@ void test_herfs_work( Params& params, bool run )
 void test_herfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_herfs_work< float >( params, run );
             break;
@@ -143,6 +139,10 @@ void test_herfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_herfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hesv.cc
+++ b/test/test_hesv.cc
@@ -97,10 +97,6 @@ void test_hesv_work( Params& params, bool run )
 void test_hesv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hesv_work< float >( params, run );
             break;
@@ -115,6 +111,10 @@ void test_hesv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hesv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hetrd.cc
+++ b/test/test_hetrd.cc
@@ -95,10 +95,6 @@ void test_hetrd_work( Params& params, bool run )
 void test_hetrd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hetrd_work< float >( params, run );
             break;
@@ -113,6 +109,10 @@ void test_hetrd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hetrd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hetrf.cc
+++ b/test/test_hetrf.cc
@@ -87,10 +87,6 @@ void test_hetrf_work( Params& params, bool run )
 void test_hetrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hetrf_work< float >( params, run );
             break;
@@ -105,6 +101,10 @@ void test_hetrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hetrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hetri.cc
+++ b/test/test_hetri.cc
@@ -103,10 +103,6 @@ void test_hetri_work( Params& params, bool run )
 void test_hetri( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hetri_work< float >( params, run );
             break;
@@ -121,6 +117,10 @@ void test_hetri( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hetri_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hetrs.cc
+++ b/test/test_hetrs.cc
@@ -100,10 +100,6 @@ void test_hetrs_work( Params& params, bool run )
 void test_hetrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hetrs_work< float >( params, run );
             break;
@@ -118,6 +114,10 @@ void test_hetrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hetrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpcon.cc
+++ b/test/test_hpcon.cc
@@ -98,10 +98,6 @@ void test_hpcon_work( Params& params, bool run )
 void test_hpcon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpcon_work< float >( params, run );
             break;
@@ -116,6 +112,10 @@ void test_hpcon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpcon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpev.cc
+++ b/test/test_hpev.cc
@@ -141,10 +141,6 @@ void test_hpev_work( Params& params, bool run )
 void test_hpev( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpev_work< float >( params, run );
             break;
@@ -159,6 +155,10 @@ void test_hpev( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpev_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpevd.cc
+++ b/test/test_hpevd.cc
@@ -139,10 +139,6 @@ void test_hpevd_work( Params& params, bool run )
 void test_hpevd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpevd_work< float >( params, run );
             break;
@@ -157,6 +153,10 @@ void test_hpevd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpevd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpevx.cc
+++ b/test/test_hpevx.cc
@@ -180,10 +180,6 @@ void test_hpevx_work( Params& params, bool run )
 void test_hpevx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpevx_work< float >( params, run );
             break;
@@ -198,6 +194,10 @@ void test_hpevx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpevx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpgst.cc
+++ b/test/test_hpgst.cc
@@ -109,10 +109,6 @@ void test_hpgst_work( Params& params, bool run )
 void test_hpgst( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpgst_work< float >( params, run );
             break;
@@ -127,6 +123,10 @@ void test_hpgst( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpgst_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpgv.cc
+++ b/test/test_hpgv.cc
@@ -214,10 +214,6 @@ void test_hpgv_work( Params& params, bool run )
 void test_hpgv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpgv_work< float >( params, run );
             break;
@@ -232,6 +228,10 @@ void test_hpgv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpgv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpgvd.cc
+++ b/test/test_hpgvd.cc
@@ -214,10 +214,6 @@ void test_hpgvd_work( Params& params, bool run )
 void test_hpgvd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpgvd_work< float >( params, run );
             break;
@@ -232,6 +228,10 @@ void test_hpgvd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpgvd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpgvx.cc
+++ b/test/test_hpgvx.cc
@@ -235,10 +235,6 @@ void test_hpgvx_work( Params& params, bool run )
 void test_hpgvx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpgvx_work< float >( params, run );
             break;
@@ -253,6 +249,10 @@ void test_hpgvx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpgvx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hprfs.cc
+++ b/test/test_hprfs.cc
@@ -122,10 +122,6 @@ void test_hprfs_work( Params& params, bool run )
 void test_hprfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hprfs_work< float >( params, run );
             break;
@@ -140,6 +136,10 @@ void test_hprfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hprfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hpsv.cc
+++ b/test/test_hpsv.cc
@@ -99,10 +99,6 @@ void test_hpsv_work( Params& params, bool run )
 void test_hpsv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hpsv_work< float >( params, run );
             break;
@@ -117,6 +113,10 @@ void test_hpsv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hpsv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hptrd.cc
+++ b/test/test_hptrd.cc
@@ -94,10 +94,6 @@ void test_hptrd_work( Params& params, bool run )
 void test_hptrd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hptrd_work< float >( params, run );
             break;
@@ -112,6 +108,10 @@ void test_hptrd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hptrd_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hptrf.cc
+++ b/test/test_hptrf.cc
@@ -87,10 +87,6 @@ void test_hptrf_work( Params& params, bool run )
 void test_hptrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hptrf_work< float >( params, run );
             break;
@@ -105,6 +101,10 @@ void test_hptrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hptrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hptri.cc
+++ b/test/test_hptri.cc
@@ -97,10 +97,6 @@ void test_hptri_work( Params& params, bool run )
 void test_hptri( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hptri_work< float >( params, run );
             break;
@@ -115,6 +111,10 @@ void test_hptri( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hptri_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hptrs.cc
+++ b/test/test_hptrs.cc
@@ -99,10 +99,6 @@ void test_hptrs_work( Params& params, bool run )
 void test_hptrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hptrs_work< float >( params, run );
             break;
@@ -117,6 +113,10 @@ void test_hptrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_hptrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lacpy.cc
+++ b/test/test_lacpy.cc
@@ -82,10 +82,6 @@ void test_lacpy_work( Params& params, bool run )
 void test_lacpy( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lacpy_work< float >( params, run );
             break;
@@ -100,6 +96,10 @@ void test_lacpy( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lacpy_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_laed4.cc
+++ b/test/test_laed4.cc
@@ -93,10 +93,6 @@ void test_laed4_work( Params& params, bool run )
 void test_laed4( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_laed4_work< float >( params, run );
             break;
@@ -108,6 +104,10 @@ void test_laed4( Params& params, bool run )
         case testsweeper::DataType::SingleComplex:
         case testsweeper::DataType::DoubleComplex:
             params.msg() = "skipping: no complex version";
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_langb.cc
+++ b/test/test_langb.cc
@@ -99,10 +99,6 @@ void test_langb_work( Params& params, bool run )
 void test_langb( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_langb_work< float >( params, run );
             break;
@@ -117,6 +113,10 @@ void test_langb( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_langb_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lange.cc
+++ b/test/test_lange.cc
@@ -105,10 +105,6 @@ void test_lange_work( Params& params, bool run )
 void test_lange( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lange_work< float >( params, run );
             break;
@@ -123,6 +119,10 @@ void test_lange( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lange_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_langt.cc
+++ b/test/test_langt.cc
@@ -93,10 +93,6 @@ void test_langt_work( Params& params, bool run )
 void test_langt( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_langt_work< float >( params, run );
             break;
@@ -111,6 +107,10 @@ void test_langt( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_langt_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lanhb.cc
+++ b/test/test_lanhb.cc
@@ -103,10 +103,6 @@ void test_lanhb_work( Params& params, bool run )
 void test_lanhb( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lanhb_work< float >( params, run );
             break;
@@ -121,6 +117,10 @@ void test_lanhb( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lanhb_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lanhe.cc
+++ b/test/test_lanhe.cc
@@ -105,10 +105,6 @@ void test_lanhe_work( Params& params, bool run )
 void test_lanhe( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lanhe_work< float >( params, run );
             break;
@@ -123,6 +119,10 @@ void test_lanhe( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lanhe_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lanhp.cc
+++ b/test/test_lanhp.cc
@@ -99,10 +99,6 @@ void test_lanhp_work( Params& params, bool run )
 void test_lanhp( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lanhp_work< float >( params, run );
             break;
@@ -117,6 +113,10 @@ void test_lanhp( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lanhp_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lanhs.cc
+++ b/test/test_lanhs.cc
@@ -103,10 +103,6 @@ void test_lanhs_work( Params& params, bool run )
 void test_lanhs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lanhs_work< float >( params, run );
             break;
@@ -121,6 +117,10 @@ void test_lanhs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lanhs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lanht.cc
+++ b/test/test_lanht.cc
@@ -90,10 +90,6 @@ void test_lanht_work( Params& params, bool run )
 void test_lanht( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lanht_work< float >( params, run );
             break;
@@ -108,6 +104,10 @@ void test_lanht( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lanht_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lansb.cc
+++ b/test/test_lansb.cc
@@ -103,10 +103,6 @@ void test_lansb_work( Params& params, bool run )
 void test_lansb( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lansb_work< float >( params, run );
             break;
@@ -121,6 +117,10 @@ void test_lansb( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lansb_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lansp.cc
+++ b/test/test_lansp.cc
@@ -99,10 +99,6 @@ void test_lansp_work( Params& params, bool run )
 void test_lansp( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lansp_work< float >( params, run );
             break;
@@ -117,6 +113,10 @@ void test_lansp( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lansp_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lanst.cc
+++ b/test/test_lanst.cc
@@ -91,10 +91,6 @@ void test_lanst_work( Params& params, bool run )
 void test_lanst( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lanst_work< float >( params, run );
             break;
@@ -106,6 +102,10 @@ void test_lanst( Params& params, bool run )
         case testsweeper::DataType::SingleComplex:
         case testsweeper::DataType::DoubleComplex:
             params.msg() = "skipping: no complex version";
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lansy.cc
+++ b/test/test_lansy.cc
@@ -105,10 +105,6 @@ void test_lansy_work( Params& params, bool run )
 void test_lansy( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lansy_work< float >( params, run );
             break;
@@ -123,6 +119,10 @@ void test_lansy( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lansy_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lantb.cc
+++ b/test/test_lantb.cc
@@ -100,10 +100,6 @@ void test_lantb_work( Params& params, bool run )
 void test_lantb( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lantb_work< float >( params, run );
             break;
@@ -118,6 +114,10 @@ void test_lantb( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lantb_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lantp.cc
+++ b/test/test_lantp.cc
@@ -96,10 +96,6 @@ void test_lantp_work( Params& params, bool run )
 void test_lantp( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lantp_work< float >( params, run );
             break;
@@ -114,6 +110,10 @@ void test_lantp( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lantp_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_lantr.cc
+++ b/test/test_lantr.cc
@@ -110,10 +110,6 @@ void test_lantr_work( Params& params, bool run )
 void test_lantr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_lantr_work< float >( params, run );
             break;
@@ -128,6 +124,10 @@ void test_lantr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_lantr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_larf.cc
+++ b/test/test_larf.cc
@@ -92,10 +92,6 @@ void test_larf_work( Params& params, bool run )
 void test_larf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_larf_work< float >( params, run );
             break;
@@ -110,6 +106,10 @@ void test_larf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_larf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_larfb.cc
+++ b/test/test_larfb.cc
@@ -132,10 +132,6 @@ void test_larfb_work( Params& params, bool run )
 void test_larfb( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_larfb_work< float >( params, run );
             break;
@@ -150,6 +146,10 @@ void test_larfb( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_larfb_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_larfg.cc
+++ b/test/test_larfg.cc
@@ -106,10 +106,6 @@ void test_larfg_work( Params& params, bool run )
 void test_larfg( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_larfg_work< float >( params, run );
             break;
@@ -124,6 +120,10 @@ void test_larfg( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_larfg_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_larfgp.cc
+++ b/test/test_larfgp.cc
@@ -111,10 +111,6 @@ void test_larfgp_work( Params& params, bool run )
 void test_larfgp( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_larfgp_work< float >( params, run );
             break;
@@ -129,6 +125,10 @@ void test_larfgp( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_larfgp_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_larft.cc
+++ b/test/test_larft.cc
@@ -153,10 +153,6 @@ void test_larft_work( Params& params, bool run )
 void test_larft( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_larft_work< float >( params, run );
             break;
@@ -171,6 +167,10 @@ void test_larft( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_larft_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_larfx.cc
+++ b/test/test_larfx.cc
@@ -91,10 +91,6 @@ void test_larfx_work( Params& params, bool run )
 void test_larfx( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_larfx_work< float >( params, run );
             break;
@@ -109,6 +105,10 @@ void test_larfx( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_larfx_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_larfy.cc
+++ b/test/test_larfy.cc
@@ -89,10 +89,6 @@ void test_larfy_work( Params& params, bool run )
 void test_larfy( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_larfy_work< float >( params, run );
             break;
@@ -107,6 +103,10 @@ void test_larfy( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_larfy_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_laset.cc
+++ b/test/test_laset.cc
@@ -80,10 +80,6 @@ void test_laset_work( Params& params, bool run )
 void test_laset( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_laset_work< float >( params, run );
             break;
@@ -98,6 +94,10 @@ void test_laset( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_laset_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_laswp.cc
+++ b/test/test_laswp.cc
@@ -91,10 +91,6 @@ void test_laswp_work( Params& params, bool run )
 void test_laswp( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_laswp_work< float >( params, run );
             break;
@@ -109,6 +105,10 @@ void test_laswp( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_laswp_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_orhr_col.cc
+++ b/test/test_orhr_col.cc
@@ -107,7 +107,7 @@ void test_orhr_col( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 #else

--- a/test/test_pbcon.cc
+++ b/test/test_pbcon.cc
@@ -107,10 +107,6 @@ void test_pbcon_work( Params& params, bool run )
 void test_pbcon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pbcon_work< float >( params, run );
             break;
@@ -125,6 +121,10 @@ void test_pbcon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pbcon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pbequ.cc
+++ b/test/test_pbequ.cc
@@ -104,10 +104,6 @@ void test_pbequ_work( Params& params, bool run )
 void test_pbequ( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pbequ_work< float >( params, run );
             break;
@@ -122,6 +118,10 @@ void test_pbequ( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pbequ_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pbrfs.cc
+++ b/test/test_pbrfs.cc
@@ -170,10 +170,6 @@ void test_pbrfs_work( Params& params, bool run )
 void test_pbrfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pbrfs_work< float >( params, run );
             break;
@@ -188,6 +184,10 @@ void test_pbrfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pbrfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pbsv.cc
+++ b/test/test_pbsv.cc
@@ -141,10 +141,6 @@ void test_pbsv_work( Params& params, bool run )
 void test_pbsv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pbsv_work< float >( params, run );
             break;
@@ -159,6 +155,10 @@ void test_pbsv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pbsv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pbtrf.cc
+++ b/test/test_pbtrf.cc
@@ -98,10 +98,6 @@ void test_pbtrf_work( Params& params, bool run )
 void test_pbtrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pbtrf_work< float >( params, run );
             break;
@@ -116,6 +112,10 @@ void test_pbtrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pbtrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pbtrs.cc
+++ b/test/test_pbtrs.cc
@@ -147,10 +147,6 @@ void test_pbtrs_work( Params& params, bool run )
 void test_pbtrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pbtrs_work< float >( params, run );
             break;
@@ -165,6 +161,10 @@ void test_pbtrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pbtrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pocon.cc
+++ b/test/test_pocon.cc
@@ -103,10 +103,6 @@ void test_pocon_work( Params& params, bool run )
 void test_pocon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pocon_work< float >( params, run );
             break;
@@ -121,6 +117,10 @@ void test_pocon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pocon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_poequ.cc
+++ b/test/test_poequ.cc
@@ -91,10 +91,6 @@ void test_poequ_work( Params& params, bool run )
 void test_poequ( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_poequ_work< float >( params, run );
             break;
@@ -109,6 +105,10 @@ void test_poequ( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_poequ_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_porfs.cc
+++ b/test/test_porfs.cc
@@ -123,10 +123,6 @@ void test_porfs_work( Params& params, bool run )
 void test_porfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_porfs_work< float >( params, run );
             break;
@@ -141,6 +137,10 @@ void test_porfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_porfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -142,10 +142,6 @@ void test_posv_work( Params& params, bool run )
 void test_posv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_posv_work< float >( params, run );
             break;
@@ -160,6 +156,10 @@ void test_posv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_posv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_potrf.cc
+++ b/test/test_potrf.cc
@@ -141,10 +141,6 @@ void test_potrf_work( Params& params, bool run )
 void test_potrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_potrf_work< float >( params, run );
             break;
@@ -159,6 +155,10 @@ void test_potrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_potrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_potrf_device.cc
+++ b/test/test_potrf_device.cc
@@ -187,7 +187,7 @@ void test_potrf_device( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_potri.cc
+++ b/test/test_potri.cc
@@ -163,10 +163,6 @@ void test_potri_work( Params& params, bool run )
 void test_potri( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_potri_work< float >( params, run );
             break;
@@ -181,6 +177,10 @@ void test_potri( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_potri_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_potrs.cc
+++ b/test/test_potrs.cc
@@ -129,10 +129,6 @@ void test_potrs_work( Params& params, bool run )
 void test_potrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_potrs_work< float >( params, run );
             break;
@@ -147,6 +143,10 @@ void test_potrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_potrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ppcon.cc
+++ b/test/test_ppcon.cc
@@ -105,10 +105,6 @@ void test_ppcon_work( Params& params, bool run )
 void test_ppcon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ppcon_work< float >( params, run );
             break;
@@ -123,6 +119,10 @@ void test_ppcon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ppcon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ppequ.cc
+++ b/test/test_ppequ.cc
@@ -101,10 +101,6 @@ void test_ppequ_work( Params& params, bool run )
 void test_ppequ( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ppequ_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_ppequ( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ppequ_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pprfs.cc
+++ b/test/test_pprfs.cc
@@ -131,10 +131,6 @@ void test_pprfs_work( Params& params, bool run )
 void test_pprfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pprfs_work< float >( params, run );
             break;
@@ -149,6 +145,10 @@ void test_pprfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pprfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ppsv.cc
+++ b/test/test_ppsv.cc
@@ -103,10 +103,6 @@ void test_ppsv_work( Params& params, bool run )
 void test_ppsv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ppsv_work< float >( params, run );
             break;
@@ -121,6 +117,10 @@ void test_ppsv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ppsv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pptrf.cc
+++ b/test/test_pptrf.cc
@@ -94,10 +94,6 @@ void test_pptrf_work( Params& params, bool run )
 void test_pptrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pptrf_work< float >( params, run );
             break;
@@ -112,6 +108,10 @@ void test_pptrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pptrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pptri.cc
+++ b/test/test_pptri.cc
@@ -101,10 +101,6 @@ void test_pptri_work( Params& params, bool run )
 void test_pptri( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pptri_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_pptri( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pptri_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pptrs.cc
+++ b/test/test_pptrs.cc
@@ -106,10 +106,6 @@ void test_pptrs_work( Params& params, bool run )
 void test_pptrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pptrs_work< float >( params, run );
             break;
@@ -124,6 +120,10 @@ void test_pptrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pptrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ptcon.cc
+++ b/test/test_ptcon.cc
@@ -99,10 +99,6 @@ void test_ptcon_work( Params& params, bool run )
 void test_ptcon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ptcon_work< float >( params, run );
             break;
@@ -117,6 +113,10 @@ void test_ptcon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ptcon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ptrfs.cc
+++ b/test/test_ptrfs.cc
@@ -126,10 +126,6 @@ void test_ptrfs_work( Params& params, bool run )
 void test_ptrfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ptrfs_work< float >( params, run );
             break;
@@ -144,6 +140,10 @@ void test_ptrfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ptrfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ptsv.cc
+++ b/test/test_ptsv.cc
@@ -101,10 +101,6 @@ void test_ptsv_work( Params& params, bool run )
 void test_ptsv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ptsv_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_ptsv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ptsv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pttrf.cc
+++ b/test/test_pttrf.cc
@@ -92,10 +92,6 @@ void test_pttrf_work( Params& params, bool run )
 void test_pttrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pttrf_work< float >( params, run );
             break;
@@ -110,6 +106,10 @@ void test_pttrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pttrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pttrs.cc
+++ b/test/test_pttrs.cc
@@ -101,10 +101,6 @@ void test_pttrs_work( Params& params, bool run )
 void test_pttrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pttrs_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_pttrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_pttrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_spcon.cc
+++ b/test/test_spcon.cc
@@ -96,10 +96,6 @@ void test_spcon_work( Params& params, bool run )
 void test_spcon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_spcon_work< float >( params, run );
             break;
@@ -114,6 +110,10 @@ void test_spcon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_spcon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sprfs.cc
+++ b/test/test_sprfs.cc
@@ -121,10 +121,6 @@ void test_sprfs_work( Params& params, bool run )
 void test_sprfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sprfs_work< float >( params, run );
             break;
@@ -139,6 +135,10 @@ void test_sprfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sprfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_spsv.cc
+++ b/test/test_spsv.cc
@@ -110,10 +110,6 @@ void test_spsv_work( Params& params, bool run )
 void test_spsv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_spsv_work< float >( params, run );
             break;
@@ -128,6 +124,10 @@ void test_spsv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_spsv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sptrf.cc
+++ b/test/test_sptrf.cc
@@ -86,10 +86,6 @@ void test_sptrf_work( Params& params, bool run )
 void test_sptrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sptrf_work< float >( params, run );
             break;
@@ -104,6 +100,10 @@ void test_sptrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sptrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sptri.cc
+++ b/test/test_sptri.cc
@@ -96,10 +96,6 @@ void test_sptri_work( Params& params, bool run )
 void test_sptri( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sptri_work< float >( params, run );
             break;
@@ -114,6 +110,10 @@ void test_sptri( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sptri_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sptrs.cc
+++ b/test/test_sptrs.cc
@@ -108,10 +108,6 @@ void test_sptrs_work( Params& params, bool run )
 void test_sptrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sptrs_work< float >( params, run );
             break;
@@ -126,6 +122,10 @@ void test_sptrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sptrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sycon.cc
+++ b/test/test_sycon.cc
@@ -94,10 +94,6 @@ void test_sycon_work( Params& params, bool run )
 void test_sycon( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sycon_work< float >( params, run );
             break;
@@ -112,6 +108,10 @@ void test_sycon( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sycon_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -148,9 +148,6 @@ void test_symv_work( Params& params, bool run )
 void test_symv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-
         case testsweeper::DataType::Single:
             test_symv_work< float, float, float >( params, run );
             break;
@@ -167,6 +164,10 @@ void test_symv( Params& params, bool run )
         case testsweeper::DataType::DoubleComplex:
             test_symv_work< std::complex<double>, std::complex<double>,
                             std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_syr.cc
+++ b/test/test_syr.cc
@@ -129,11 +129,6 @@ void test_syr_work( Params& params, bool run )
 void test_syr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            //test_syr_work< int64_t >( params, run );
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_syr_work< float, float >( params, run );
             break;
@@ -150,6 +145,10 @@ void test_syr( Params& params, bool run )
         case testsweeper::DataType::DoubleComplex:
             test_syr_work< std::complex<double>, std::complex<double> >
                 ( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_syrfs.cc
+++ b/test/test_syrfs.cc
@@ -122,10 +122,6 @@ void test_syrfs_work( Params& params, bool run )
 void test_syrfs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_syrfs_work< float >( params, run );
             break;
@@ -140,6 +136,10 @@ void test_syrfs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_syrfs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sysv.cc
+++ b/test/test_sysv.cc
@@ -97,10 +97,6 @@ void test_sysv_work( Params& params, bool run )
 void test_sysv( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sysv_work< float >( params, run );
             break;
@@ -115,6 +111,10 @@ void test_sysv( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sysv_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sysv_aa.cc
+++ b/test/test_sysv_aa.cc
@@ -108,10 +108,6 @@ void test_sysv_aa_work( Params& params, bool run )
 void test_sysv_aa( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sysv_aa_work< float >( params, run );
             break;
@@ -126,6 +122,10 @@ void test_sysv_aa( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sysv_aa_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sysv_rk.cc
+++ b/test/test_sysv_rk.cc
@@ -107,10 +107,6 @@ void test_sysv_rk_work( Params& params, bool run )
 void test_sysv_rk( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sysv_rk_work< float >( params, run );
             break;
@@ -125,6 +121,10 @@ void test_sysv_rk( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sysv_rk_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sysv_rook.cc
+++ b/test/test_sysv_rook.cc
@@ -103,10 +103,6 @@ void test_sysv_rook_work( Params& params, bool run )
 void test_sysv_rook( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sysv_rook_work< float >( params, run );
             break;
@@ -121,6 +117,10 @@ void test_sysv_rook( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sysv_rook_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytrf.cc
+++ b/test/test_sytrf.cc
@@ -87,10 +87,6 @@ void test_sytrf_work( Params& params, bool run )
 void test_sytrf( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytrf_work< float >( params, run );
             break;
@@ -105,6 +101,10 @@ void test_sytrf( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytrf_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytrf_aa.cc
+++ b/test/test_sytrf_aa.cc
@@ -94,10 +94,6 @@ void test_sytrf_aa_work( Params& params, bool run )
 void test_sytrf_aa( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytrf_aa_work< float >( params, run );
             break;
@@ -112,6 +108,10 @@ void test_sytrf_aa( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytrf_aa_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytrf_rk.cc
+++ b/test/test_sytrf_rk.cc
@@ -97,10 +97,6 @@ void test_sytrf_rk_work( Params& params, bool run )
 void test_sytrf_rk( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytrf_rk_work< float >( params, run );
             break;
@@ -115,6 +111,10 @@ void test_sytrf_rk( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytrf_rk_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytrf_rook.cc
+++ b/test/test_sytrf_rook.cc
@@ -93,10 +93,6 @@ void test_sytrf_rook_work( Params& params, bool run )
 void test_sytrf_rook( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytrf_rook_work< float >( params, run );
             break;
@@ -111,6 +107,10 @@ void test_sytrf_rook( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytrf_rook_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytri.cc
+++ b/test/test_sytri.cc
@@ -101,10 +101,6 @@ void test_sytri_work( Params& params, bool run )
 void test_sytri( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytri_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_sytri( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytri_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytrs.cc
+++ b/test/test_sytrs.cc
@@ -110,10 +110,6 @@ void test_sytrs_work( Params& params, bool run )
 void test_sytrs( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytrs_work< float >( params, run );
             break;
@@ -128,6 +124,10 @@ void test_sytrs( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytrs_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytrs_aa.cc
+++ b/test/test_sytrs_aa.cc
@@ -102,10 +102,6 @@ void test_sytrs_aa_work( Params& params, bool run )
 void test_sytrs_aa( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytrs_aa_work< float >( params, run );
             break;
@@ -120,6 +116,10 @@ void test_sytrs_aa( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytrs_aa_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sytrs_rook.cc
+++ b/test/test_sytrs_rook.cc
@@ -106,10 +106,6 @@ void test_sytrs_rook_work( Params& params, bool run )
 void test_sytrs_rook( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sytrs_rook_work< float >( params, run );
             break;
@@ -124,6 +120,10 @@ void test_sytrs_rook( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_sytrs_rook_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tgexc.cc
+++ b/test/test_tgexc.cc
@@ -148,10 +148,6 @@ void test_tgexc_work( Params& params, bool run )
 void test_tgexc( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tgexc_work< float >( params, run );
             break;
@@ -166,6 +162,10 @@ void test_tgexc( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tgexc_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tgsen.cc
+++ b/test/test_tgsen.cc
@@ -165,10 +165,6 @@ void test_tgsen_work( Params& params, bool run )
 void test_tgsen( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tgsen_work< float >( params, run );
             break;
@@ -183,6 +179,10 @@ void test_tgsen( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tgsen_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tplqt.cc
+++ b/test/test_tplqt.cc
@@ -185,10 +185,6 @@ void test_tplqt_work( Params& params, bool run )
 void test_tplqt( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tplqt_work< float >( params, run );
             break;
@@ -203,6 +199,10 @@ void test_tplqt( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tplqt_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tplqt2.cc
+++ b/test/test_tplqt2.cc
@@ -184,10 +184,6 @@ void test_tplqt2_work( Params& params, bool run )
 void test_tplqt2( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tplqt2_work< float >( params, run );
             break;
@@ -202,6 +198,10 @@ void test_tplqt2( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tplqt2_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tpmlqt.cc
+++ b/test/test_tpmlqt.cc
@@ -158,10 +158,6 @@ void test_tpmlqt_work( Params& params, bool run )
 void test_tpmlqt( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tpmlqt_work< float >( params, run );
             break;
@@ -176,6 +172,10 @@ void test_tpmlqt( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tpmlqt_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tpmqrt.cc
+++ b/test/test_tpmqrt.cc
@@ -179,10 +179,6 @@ void test_tpmqrt_work( Params& params, bool run )
 void test_tpmqrt( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tpmqrt_work< float >( params, run );
             break;
@@ -197,6 +193,10 @@ void test_tpmqrt( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tpmqrt_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tpqrt.cc
+++ b/test/test_tpqrt.cc
@@ -187,10 +187,6 @@ void test_tpqrt_work( Params& params, bool run )
 void test_tpqrt( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tpqrt_work< float >( params, run );
             break;
@@ -205,6 +201,10 @@ void test_tpqrt( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tpqrt_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tpqrt2.cc
+++ b/test/test_tpqrt2.cc
@@ -187,10 +187,6 @@ void test_tpqrt2_work( Params& params, bool run )
 void test_tpqrt2( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tpqrt2_work< float >( params, run );
             break;
@@ -205,6 +201,10 @@ void test_tpqrt2( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tpqrt2_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tprfb.cc
+++ b/test/test_tprfb.cc
@@ -134,10 +134,6 @@ void test_tprfb_work( Params& params, bool run )
 void test_tprfb( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tprfb_work< float >( params, run );
             break;
@@ -152,6 +148,10 @@ void test_tprfb( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_tprfb_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_unghr.cc
+++ b/test/test_unghr.cc
@@ -97,10 +97,6 @@ void test_unghr_work( Params& params, bool run )
 void test_unghr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_unghr_work< float >( params, run );
             break;
@@ -115,6 +111,10 @@ void test_unghr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_unghr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_unglq.cc
+++ b/test/test_unglq.cc
@@ -150,10 +150,6 @@ void test_unglq_work( Params& params, bool run )
 void test_unglq( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_unglq_work< float >( params, run );
             break;
@@ -168,6 +164,10 @@ void test_unglq( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_unglq_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ungql.cc
+++ b/test/test_ungql.cc
@@ -153,10 +153,6 @@ void test_ungql_work( Params& params, bool run )
 void test_ungql( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ungql_work< float >( params, run );
             break;
@@ -171,6 +167,10 @@ void test_ungql( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ungql_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ungqr.cc
+++ b/test/test_ungqr.cc
@@ -153,10 +153,6 @@ void test_ungqr_work( Params& params, bool run )
 void test_ungqr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ungqr_work< float >( params, run );
             break;
@@ -171,6 +167,10 @@ void test_ungqr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ungqr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ungrq.cc
+++ b/test/test_ungrq.cc
@@ -147,10 +147,6 @@ void test_ungrq_work( Params& params, bool run )
 void test_ungrq( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ungrq_work< float >( params, run );
             break;
@@ -165,6 +161,10 @@ void test_ungrq( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ungrq_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ungtr.cc
+++ b/test/test_ungtr.cc
@@ -101,10 +101,6 @@ void test_ungtr_work( Params& params, bool run )
 void test_ungtr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ungtr_work< float >( params, run );
             break;
@@ -119,6 +115,10 @@ void test_ungtr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_ungtr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_unhr_col.cc
+++ b/test/test_unhr_col.cc
@@ -115,7 +115,7 @@ void test_unhr_col( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 #else

--- a/test/test_unmhr.cc
+++ b/test/test_unmhr.cc
@@ -113,10 +113,6 @@ void test_unmhr_work( Params& params, bool run )
 void test_unmhr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_unmhr_work< float >( params, run );
             break;
@@ -131,6 +127,10 @@ void test_unmhr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_unmhr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_unmtr.cc
+++ b/test/test_unmtr.cc
@@ -109,10 +109,6 @@ void test_unmtr_work( Params& params, bool run )
 void test_unmtr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_unmtr_work< float >( params, run );
             break;
@@ -127,6 +123,10 @@ void test_unmtr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_unmtr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_upgtr.cc
+++ b/test/test_upgtr.cc
@@ -102,10 +102,6 @@ void test_upgtr_work( Params& params, bool run )
 void test_upgtr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_upgtr_work< float >( params, run );
             break;
@@ -120,6 +116,10 @@ void test_upgtr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_upgtr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_upmtr.cc
+++ b/test/test_upmtr.cc
@@ -107,10 +107,6 @@ void test_upmtr_work( Params& params, bool run )
 void test_upmtr( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_upmtr_work< float >( params, run );
             break;
@@ -125,6 +121,10 @@ void test_upmtr( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_upmtr_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }


### PR DESCRIPTION
## Problem

The introduction of the `Half` datatype in `Testsweeper` causes warnings when compiling a lot of the test files.

## Solution

In this PR, we update the test files where one of the switch cases is on `Integer`, by removing it, and adding a default case that throw a runtime exception on the datatype.
```
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-

+
+        default:
+            throw std::runtime_error( "unknown datatype" );
+            break;
```

Moreover, we fix a few test files that were throwing an `std::exception()` in the default case, by replacing it with the same runtime error, to be consistent.
```
         default:                                                                                                                                                                                                                                                               
-            throw std::exception();                                                                                                                                                                                                                                            
+            throw std::runtime_error( "unknown datatype" );                                                                                                                                                                                                                    
             break;
```