### PR TITLE
define LAPACK_FORTRAN_STRLEN_END during config. See #44.

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 #if defined(FORTRAN_UPPER) || defined(BLAS_FORTRAN_UPPER) || defined(LAPACK_FORTRAN_UPPER)
     #define FORTRAN_NAME( lower, UPPER ) UPPER
 #elif defined(FORTRAN_LOWER) || defined(BLAS_FORTRAN_LOWER) || defined(LAPACK_FORTRAN_LOWER)
@@ -19,13 +19,22 @@
     #error "must define one of FORTRAN_ADD_, FORTRAN_LOWER, FORTRAN_UPPER"
 #endif
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 #if defined(BLAS_ILP64) || defined(LAPACK_ILP64)
     typedef int64_t blas_int;
     typedef int64_t lapack_int;
 #else
     typedef int blas_int;
     typedef int lapack_int;
+#endif
+
+//------------------------------------------------------------------------------
+#ifndef BLAS_FORTRAN_STRLEN_END
+#define BLAS_FORTRAN_STRLEN_END
+#endif
+
+#ifndef LAPACK_FORTRAN_STRLEN_END
+#define LAPACK_FORTRAN_STRLEN_END
 #endif
 
 #endif // CONFIG_H

--- a/include/lapack/fortran.h
+++ b/include/lapack/fortran.h
@@ -9,10 +9,12 @@
 #include "lapack/config.h"
 #include "lapack/mangling.h"
 
-/* It seems all current Fortran compilers put strlen at end.
-*  Some historical compilers put strlen after the str argument
-*  or make the str argument into a struct. */
+// It seems all current Fortran compilers put strlen at end.
+// Some historical compilers put strlen after the str argument
+// or make the str argument into a struct.
+#ifndef LAPACK_FORTRAN_STRLEN_END
 #define LAPACK_FORTRAN_STRLEN_END
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
@weslleyspereira Does this fix the problem? Apparently the earlier fix in PR #49 left out actually defining this `#define` during the configure process.