### PR TITLE
For enums, use to_string, from_string.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,6 +517,7 @@ add_library(
     src/unmtr.cc
     src/upgtr.cc
     src/upmtr.cc
+    src/util.cc
     src/version.cc
 
     src/cuda/cuda_common.cc

--- a/src/bbcsd.cc
+++ b/src/bbcsd.cc
@@ -46,11 +46,11 @@ int64_t bbcsd(
         lapack_error_if( std::abs(ldv1t) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv2t) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu1_ = job_csd2char( jobu1 );
-    char jobu2_ = job_csd2char( jobu2 );
-    char jobv1t_ = job_csd2char( jobv1t );
-    char jobv2t_ = job_csd2char( jobv2t );
-    char trans_ = op2char( trans );
+    char jobu1_ = to_char_csd( jobu1 );
+    char jobu2_ = to_char_csd( jobu2 );
+    char jobv1t_ = to_char_csd( jobv1t );
+    char jobv2t_ = to_char_csd( jobv2t );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int q_ = (lapack_int) q;
@@ -142,11 +142,11 @@ int64_t bbcsd(
         lapack_error_if( std::abs(ldv1t) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv2t) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu1_ = job_csd2char( jobu1 );
-    char jobu2_ = job_csd2char( jobu2 );
-    char jobv1t_ = job_csd2char( jobv1t );
-    char jobv2t_ = job_csd2char( jobv2t );
-    char trans_ = op2char( trans );
+    char jobu1_ = to_char_csd( jobu1 );
+    char jobu2_ = to_char_csd( jobu2 );
+    char jobv1t_ = to_char_csd( jobv1t );
+    char jobv2t_ = to_char_csd( jobv2t );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int q_ = (lapack_int) q;
@@ -238,11 +238,11 @@ int64_t bbcsd(
         lapack_error_if( std::abs(ldv1t) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv2t) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu1_ = job_csd2char( jobu1 );
-    char jobu2_ = job_csd2char( jobu2 );
-    char jobv1t_ = job_csd2char( jobv1t );
-    char jobv2t_ = job_csd2char( jobv2t );
-    char trans_ = op2char( trans );
+    char jobu1_ = to_char_csd( jobu1 );
+    char jobu2_ = to_char_csd( jobu2 );
+    char jobv1t_ = to_char_csd( jobv1t );
+    char jobv2t_ = to_char_csd( jobv2t );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int q_ = (lapack_int) q;
@@ -519,11 +519,11 @@ int64_t bbcsd(
         lapack_error_if( std::abs(ldv1t) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv2t) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu1_ = job_csd2char( jobu1 );
-    char jobu2_ = job_csd2char( jobu2 );
-    char jobv1t_ = job_csd2char( jobv1t );
-    char jobv2t_ = job_csd2char( jobv2t );
-    char trans_ = op2char( trans );
+    char jobu1_ = to_char_csd( jobu1 );
+    char jobu2_ = to_char_csd( jobu2 );
+    char jobv1t_ = to_char_csd( jobv1t );
+    char jobv2t_ = to_char_csd( jobv2t );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int q_ = (lapack_int) q;

--- a/src/bdsdc.cc
+++ b/src/bdsdc.cc
@@ -32,8 +32,8 @@ int64_t bdsdc(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char compq_ = job_comp2char( compq );
+    char uplo_ = to_char( uplo );
+    char compq_ = to_char_comp( compq );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldu_ = (lapack_int) ldu;
     lapack_int ldvt_ = (lapack_int) ldvt;
@@ -198,8 +198,8 @@ int64_t bdsdc(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char compq_ = job_comp2char( compq );
+    char uplo_ = to_char( uplo );
+    char compq_ = to_char_comp( compq );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldu_ = (lapack_int) ldu;
     lapack_int ldvt_ = (lapack_int) ldvt;

--- a/src/bdsqr.cc
+++ b/src/bdsqr.cc
@@ -35,7 +35,7 @@ int64_t bdsqr(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ncvt_ = (lapack_int) ncvt;
     lapack_int nru_ = (lapack_int) nru;
@@ -83,7 +83,7 @@ int64_t bdsqr(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ncvt_ = (lapack_int) ncvt;
     lapack_int nru_ = (lapack_int) nru;
@@ -131,7 +131,7 @@ int64_t bdsqr(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ncvt_ = (lapack_int) ncvt;
     lapack_int nru_ = (lapack_int) nru;
@@ -278,7 +278,7 @@ int64_t bdsqr(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ncvt_ = (lapack_int) ncvt;
     lapack_int nru_ = (lapack_int) nru;

--- a/src/bdsvdx.cc
+++ b/src/bdsvdx.cc
@@ -34,9 +34,9 @@ int64_t bdsvdx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char uplo_ = to_char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -209,9 +209,9 @@ int64_t bdsvdx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char uplo_ = to_char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/disna.cc
+++ b/src/disna.cc
@@ -25,7 +25,7 @@ int64_t disna(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobcond_ = jobcond2char( jobcond );
+    char jobcond_ = to_char( jobcond );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
@@ -52,7 +52,7 @@ int64_t disna(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobcond_ = jobcond2char( jobcond );
+    char jobcond_ = to_char( jobcond );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;

--- a/src/gbbrd.cc
+++ b/src/gbbrd.cc
@@ -38,7 +38,7 @@ int64_t gbbrd(
         lapack_error_if( std::abs(ldpt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ncc_ = (lapack_int) ncc;
@@ -92,7 +92,7 @@ int64_t gbbrd(
         lapack_error_if( std::abs(ldpt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ncc_ = (lapack_int) ncc;
@@ -146,7 +146,7 @@ int64_t gbbrd(
         lapack_error_if( std::abs(ldpt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ncc_ = (lapack_int) ncc;
@@ -287,7 +287,7 @@ int64_t gbbrd(
         lapack_error_if( std::abs(ldpt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ncc_ = (lapack_int) ncc;

--- a/src/gbcon.cc
+++ b/src/gbcon.cc
@@ -30,7 +30,7 @@ int64_t gbcon(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -76,7 +76,7 @@ int64_t gbcon(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -122,7 +122,7 @@ int64_t gbcon(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -220,7 +220,7 @@ int64_t gbcon(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;

--- a/src/gbrfs.cc
+++ b/src/gbrfs.cc
@@ -38,7 +38,7 @@ int64_t gbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -101,7 +101,7 @@ int64_t gbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -164,7 +164,7 @@ int64_t gbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -313,7 +313,7 @@ int64_t gbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;

--- a/src/gbrfsx.cc
+++ b/src/gbrfsx.cc
@@ -47,8 +47,8 @@ int64_t gbrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -124,8 +124,8 @@ int64_t gbrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -201,8 +201,8 @@ int64_t gbrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -579,8 +579,8 @@ int64_t gbrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;

--- a/src/gbsvx.cc
+++ b/src/gbsvx.cc
@@ -42,9 +42,9 @@ int64_t gbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -84,7 +84,7 @@ int64_t gbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );
     #endif
@@ -118,9 +118,9 @@ int64_t gbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -160,7 +160,7 @@ int64_t gbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );
     #endif
@@ -194,9 +194,9 @@ int64_t gbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -236,7 +236,7 @@ int64_t gbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );
     #endif
@@ -491,9 +491,9 @@ int64_t gbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -533,7 +533,7 @@ int64_t gbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );
     #endif

--- a/src/gbtrs.cc
+++ b/src/gbtrs.cc
@@ -32,7 +32,7 @@ int64_t gbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -77,7 +77,7 @@ int64_t gbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -122,7 +122,7 @@ int64_t gbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -229,7 +229,7 @@ int64_t gbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;

--- a/src/gebak.cc
+++ b/src/gebak.cc
@@ -29,8 +29,8 @@ int64_t gebak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -64,8 +64,8 @@ int64_t gebak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -99,8 +99,8 @@ int64_t gebak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -183,8 +183,8 @@ int64_t gebak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;

--- a/src/gebal.cc
+++ b/src/gebal.cc
@@ -28,7 +28,7 @@ int64_t gebal(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ilo_ = (lapack_int) *ilo;
@@ -62,7 +62,7 @@ int64_t gebal(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ilo_ = (lapack_int) *ilo;
@@ -96,7 +96,7 @@ int64_t gebal(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ilo_ = (lapack_int) *ilo;
@@ -219,7 +219,7 @@ int64_t gebal(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ilo_ = (lapack_int) *ilo;

--- a/src/gecon.cc
+++ b/src/gecon.cc
@@ -27,7 +27,7 @@ int64_t gecon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -60,7 +60,7 @@ int64_t gecon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -93,7 +93,7 @@ int64_t gecon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -164,7 +164,7 @@ int64_t gecon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/gees.cc
+++ b/src/gees.cc
@@ -29,8 +29,8 @@ int64_t gees(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;
@@ -99,8 +99,8 @@ int64_t gees(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;
@@ -169,8 +169,8 @@ int64_t gees(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;
@@ -233,8 +233,8 @@ int64_t gees(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;

--- a/src/geesx.cc
+++ b/src/geesx.cc
@@ -31,9 +31,9 @@ int64_t geesx(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;
@@ -109,9 +109,9 @@ int64_t geesx(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;
@@ -187,9 +187,9 @@ int64_t geesx(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;
@@ -254,9 +254,9 @@ int64_t geesx(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvs) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvs_ = job2char( jobvs );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvs_ = to_char( jobvs );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int sdim_ = (lapack_int) *sdim;

--- a/src/geev.cc
+++ b/src/geev.cc
@@ -31,8 +31,8 @@ int64_t geev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldvl_ = (lapack_int) ldvl;
@@ -96,8 +96,8 @@ int64_t geev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldvl_ = (lapack_int) ldvl;
@@ -161,8 +161,8 @@ int64_t geev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldvl_ = (lapack_int) ldvl;
@@ -322,8 +322,8 @@ int64_t geev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldvl_ = (lapack_int) ldvl;

--- a/src/gels.cc
+++ b/src/gels.cc
@@ -34,7 +34,7 @@ int64_t gels(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -90,7 +90,7 @@ int64_t gels(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -142,7 +142,7 @@ int64_t gels(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -284,7 +284,7 @@ int64_t gels(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;

--- a/src/gemlq.cc
+++ b/src/gemlq.cc
@@ -33,8 +33,8 @@ int64_t gemlq(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -90,8 +90,8 @@ int64_t gemlq(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -147,8 +147,8 @@ int64_t gemlq(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -204,8 +204,8 @@ int64_t gemlq(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/gemqr.cc
+++ b/src/gemqr.cc
@@ -33,8 +33,8 @@ int64_t gemqr(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -90,8 +90,8 @@ int64_t gemqr(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -147,8 +147,8 @@ int64_t gemqr(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -204,8 +204,8 @@ int64_t gemqr(
         lapack_error_if( std::abs(tsize) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/gemqrt.cc
+++ b/src/gemqrt.cc
@@ -38,8 +38,8 @@ int64_t gemqrt(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -90,8 +90,8 @@ int64_t gemqrt(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -142,8 +142,8 @@ int64_t gemqrt(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -269,8 +269,8 @@ int64_t gemqrt(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/gerfs.cc
+++ b/src/gerfs.cc
@@ -36,7 +36,7 @@ int64_t gerfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -95,7 +95,7 @@ int64_t gerfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -154,7 +154,7 @@ int64_t gerfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -287,7 +287,7 @@ int64_t gerfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/gerfsx.cc
+++ b/src/gerfsx.cc
@@ -45,8 +45,8 @@ int64_t gerfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -118,8 +118,8 @@ int64_t gerfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -191,8 +191,8 @@ int64_t gerfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -536,8 +536,8 @@ int64_t gerfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( equed );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/gesdd.cc
+++ b/src/gesdd.cc
@@ -32,7 +32,7 @@ int64_t gesdd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -94,7 +94,7 @@ int64_t gesdd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -156,7 +156,7 @@ int64_t gesdd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -341,7 +341,7 @@ int64_t gesdd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/gesvd.cc
+++ b/src/gesvd.cc
@@ -32,8 +32,8 @@ int64_t gesvd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -91,8 +91,8 @@ int64_t gesvd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -150,8 +150,8 @@ int64_t gesvd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -322,8 +322,8 @@ int64_t gesvd(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/gesvdx.cc
+++ b/src/gesvdx.cc
@@ -37,9 +37,9 @@ int64_t gesvdx(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
-    char range_ = range2char( range );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
+    char range_ = to_char( range );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -108,9 +108,9 @@ int64_t gesvdx(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
-    char range_ = range2char( range );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
+    char range_ = to_char( range );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -179,9 +179,9 @@ int64_t gesvdx(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
-    char range_ = range2char( range );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
+    char range_ = to_char( range );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -384,9 +384,9 @@ int64_t gesvdx(
         lapack_error_if( std::abs(ldu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvt) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job2char( jobu );
-    char jobvt_ = job2char( jobvt );
-    char range_ = range2char( range );
+    char jobu_ = to_char( jobu );
+    char jobvt_ = to_char( jobvt );
+    char range_ = to_char( range );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/gesvx.cc
+++ b/src/gesvx.cc
@@ -41,9 +41,9 @@ int64_t gesvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -81,7 +81,7 @@ int64_t gesvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     *rpivotgrowth = work[0];
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );
@@ -115,9 +115,9 @@ int64_t gesvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -155,7 +155,7 @@ int64_t gesvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     *rpivotgrowth = work[0];
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );
@@ -189,9 +189,9 @@ int64_t gesvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -229,7 +229,7 @@ int64_t gesvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     *rpivotgrowth = rwork[0];
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );
@@ -474,9 +474,9 @@ int64_t gesvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -514,7 +514,7 @@ int64_t gesvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     *rpivotgrowth = rwork[0];
     #ifndef LAPACK_ILP64
         std::copy( ipiv_.begin(), ipiv_.end(), ipiv );

--- a/src/getrs.cc
+++ b/src/getrs.cc
@@ -30,7 +30,7 @@ int64_t getrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -72,7 +72,7 @@ int64_t getrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -114,7 +114,7 @@ int64_t getrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -209,7 +209,7 @@ int64_t getrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/getsls.cc
+++ b/src/getsls.cc
@@ -35,7 +35,7 @@ int64_t getsls(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -103,7 +103,7 @@ int64_t getsls(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -167,7 +167,7 @@ int64_t getsls(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -231,7 +231,7 @@ int64_t getsls(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;

--- a/src/ggbak.cc
+++ b/src/ggbak.cc
@@ -29,8 +29,8 @@ int64_t ggbak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -65,8 +65,8 @@ int64_t ggbak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -101,8 +101,8 @@ int64_t ggbak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -137,8 +137,8 @@ int64_t ggbak(
         lapack_error_if( std::abs(m) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
-    char side_ = side2char( side );
+    char balance_ = to_char( balance );
+    char side_ = to_char( side );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;

--- a/src/ggbal.cc
+++ b/src/ggbal.cc
@@ -31,7 +31,7 @@ int64_t ggbal(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -77,7 +77,7 @@ int64_t ggbal(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -123,7 +123,7 @@ int64_t ggbal(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -169,7 +169,7 @@ int64_t ggbal(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char balance_ = balance2char( balance );
+    char balance_ = to_char( balance );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/gges.cc
+++ b/src/gges.cc
@@ -35,9 +35,9 @@ int64_t gges(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -120,9 +120,9 @@ int64_t gges(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -205,9 +205,9 @@ int64_t gges(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -284,9 +284,9 @@ int64_t gges(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/gges3.cc
+++ b/src/gges3.cc
@@ -37,9 +37,9 @@ int64_t gges3(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -122,9 +122,9 @@ int64_t gges3(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -207,9 +207,9 @@ int64_t gges3(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -286,9 +286,9 @@ int64_t gges3(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/ggesx.cc
+++ b/src/ggesx.cc
@@ -37,10 +37,10 @@ int64_t ggesx(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -134,10 +134,10 @@ int64_t ggesx(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -231,10 +231,10 @@ int64_t ggesx(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -322,10 +322,10 @@ int64_t ggesx(
         lapack_error_if( std::abs(ldvsl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvsr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvsl_ = job2char( jobvsl );
-    char jobvsr_ = job2char( jobvsr );
-    char sort_ = sort2char( sort );
-    char sense_ = sense2char( sense );
+    char jobvsl_ = to_char( jobvsl );
+    char jobvsr_ = to_char( jobvsr );
+    char sort_ = to_char( sort );
+    char sense_ = to_char( sense );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/ggev.cc
+++ b/src/ggev.cc
@@ -33,8 +33,8 @@ int64_t ggev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -105,8 +105,8 @@ int64_t ggev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -177,8 +177,8 @@ int64_t ggev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -245,8 +245,8 @@ int64_t ggev(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/ggev3.cc
+++ b/src/ggev3.cc
@@ -35,8 +35,8 @@ int64_t ggev3(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -107,8 +107,8 @@ int64_t ggev3(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -179,8 +179,8 @@ int64_t ggev3(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -247,8 +247,8 @@ int64_t ggev3(
         lapack_error_if( std::abs(ldvl) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobvl_ = job2char( jobvl );
-    char jobvr_ = job2char( jobvr );
+    char jobvl_ = to_char( jobvl );
+    char jobvr_ = to_char( jobvr );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/gghrd.cc
+++ b/src/gghrd.cc
@@ -32,8 +32,8 @@ int64_t gghrd(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -74,8 +74,8 @@ int64_t gghrd(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -116,8 +116,8 @@ int64_t gghrd(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -158,8 +158,8 @@ int64_t gghrd(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;

--- a/src/ggsvd3.cc
+++ b/src/ggsvd3.cc
@@ -41,9 +41,9 @@ int64_t ggsvd3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int p_ = (lapack_int) p;
@@ -125,9 +125,9 @@ int64_t ggsvd3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int p_ = (lapack_int) p;
@@ -209,9 +209,9 @@ int64_t ggsvd3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int p_ = (lapack_int) p;
@@ -297,9 +297,9 @@ int64_t ggsvd3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int p_ = (lapack_int) p;

--- a/src/ggsvp3.cc
+++ b/src/ggsvp3.cc
@@ -40,9 +40,9 @@ int64_t ggsvp3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;
@@ -121,9 +121,9 @@ int64_t ggsvp3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;
@@ -202,9 +202,9 @@ int64_t ggsvp3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;
@@ -287,9 +287,9 @@ int64_t ggsvp3(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = jobu2char( jobu );
-    char jobv_ = job2char( jobv );
-    char jobq_ = jobq2char( jobq );
+    char jobu_ = to_char_jobu( jobu );
+    char jobv_ = to_char( jobv );
+    char jobq_ = to_char_jobq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;

--- a/src/gtcon.cc
+++ b/src/gtcon.cc
@@ -30,7 +30,7 @@ int64_t gtcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -76,7 +76,7 @@ int64_t gtcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -122,7 +122,7 @@ int64_t gtcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -222,7 +222,7 @@ int64_t gtcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy

--- a/src/gtrfs.cc
+++ b/src/gtrfs.cc
@@ -39,7 +39,7 @@ int64_t gtrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -104,7 +104,7 @@ int64_t gtrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -169,7 +169,7 @@ int64_t gtrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -325,7 +325,7 @@ int64_t gtrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/gtsvx.cc
+++ b/src/gtsvx.cc
@@ -40,8 +40,8 @@ int64_t gtsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -110,8 +110,8 @@ int64_t gtsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -180,8 +180,8 @@ int64_t gtsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -406,8 +406,8 @@ int64_t gtsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char trans_ = op2char( trans );
+    char fact_ = to_char( fact );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/gttrs.cc
+++ b/src/gttrs.cc
@@ -32,7 +32,7 @@ int64_t gttrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -77,7 +77,7 @@ int64_t gttrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -122,7 +122,7 @@ int64_t gttrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -232,7 +232,7 @@ int64_t gttrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/hbev.cc
+++ b/src/hbev.cc
@@ -29,8 +29,8 @@ int64_t hbev(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -69,8 +69,8 @@ int64_t hbev(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/hbev_2stage.cc
+++ b/src/hbev_2stage.cc
@@ -31,8 +31,8 @@ int64_t hbev_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -88,8 +88,8 @@ int64_t hbev_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/hbevd.cc
+++ b/src/hbevd.cc
@@ -29,8 +29,8 @@ int64_t hbevd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -92,8 +92,8 @@ int64_t hbevd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/hbevd_2stage.cc
+++ b/src/hbevd_2stage.cc
@@ -31,8 +31,8 @@ int64_t hbevd_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -94,8 +94,8 @@ int64_t hbevd_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/hbevx.cc
+++ b/src/hbevx.cc
@@ -35,9 +35,9 @@ int64_t hbevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -103,9 +103,9 @@ int64_t hbevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/hbevx_2stage.cc
+++ b/src/hbevx_2stage.cc
@@ -37,9 +37,9 @@ int64_t hbevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -126,9 +126,9 @@ int64_t hbevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/hbgst.cc
+++ b/src/hbgst.cc
@@ -31,8 +31,8 @@ int64_t hbgst(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -75,8 +75,8 @@ int64_t hbgst(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/hbgv.cc
+++ b/src/hbgv.cc
@@ -32,8 +32,8 @@ int64_t hbgv(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -78,8 +78,8 @@ int64_t hbgv(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/hbgvd.cc
+++ b/src/hbgvd.cc
@@ -32,8 +32,8 @@ int64_t hbgvd(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -105,8 +105,8 @@ int64_t hbgvd(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/hbgvx.cc
+++ b/src/hbgvx.cc
@@ -38,9 +38,9 @@ int64_t hbgvx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -112,9 +112,9 @@ int64_t hbgvx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/hbtrd.cc
+++ b/src/hbtrd.cc
@@ -30,8 +30,8 @@ int64_t hbtrd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -70,8 +70,8 @@ int64_t hbtrd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/hecon.cc
+++ b/src/hecon.cc
@@ -28,7 +28,7 @@ int64_t hecon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -112,7 +112,7 @@ int64_t hecon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hecon_rk.cc
+++ b/src/hecon_rk.cc
@@ -31,7 +31,7 @@ int64_t hecon_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -151,7 +151,7 @@ int64_t hecon_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/heequb.cc
+++ b/src/heequb.cc
@@ -29,7 +29,7 @@ int64_t heequb(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -108,7 +108,7 @@ int64_t heequb(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/heev.cc
+++ b/src/heev.cc
@@ -27,8 +27,8 @@ int64_t heev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -125,8 +125,8 @@ int64_t heev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/heev_2stage.cc
+++ b/src/heev_2stage.cc
@@ -29,8 +29,8 @@ int64_t heev_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -157,8 +157,8 @@ int64_t heev_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/heevd.cc
+++ b/src/heevd.cc
@@ -27,8 +27,8 @@ int64_t heevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -143,8 +143,8 @@ int64_t heevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/heevd_2stage.cc
+++ b/src/heevd_2stage.cc
@@ -29,8 +29,8 @@ int64_t heevd_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -175,8 +175,8 @@ int64_t heevd_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/heevr.cc
+++ b/src/heevr.cc
@@ -33,9 +33,9 @@ int64_t heevr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -309,9 +309,9 @@ int64_t heevr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/heevr_2stage.cc
+++ b/src/heevr_2stage.cc
@@ -35,9 +35,9 @@ int64_t heevr_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -341,9 +341,9 @@ int64_t heevr_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/heevx.cc
+++ b/src/heevx.cc
@@ -33,9 +33,9 @@ int64_t heevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -244,9 +244,9 @@ int64_t heevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/heevx_2stage.cc
+++ b/src/heevx_2stage.cc
@@ -35,9 +35,9 @@ int64_t heevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -276,9 +276,9 @@ int64_t heevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/hegst.cc
+++ b/src/hegst.cc
@@ -28,7 +28,7 @@ int64_t hegst(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -59,7 +59,7 @@ int64_t hegst(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/hegv.cc
+++ b/src/hegv.cc
@@ -30,8 +30,8 @@ int64_t hegv(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -87,8 +87,8 @@ int64_t hegv(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/hegv_2stage.cc
+++ b/src/hegv_2stage.cc
@@ -32,8 +32,8 @@ int64_t hegv_2stage(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -89,8 +89,8 @@ int64_t hegv_2stage(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/hegvd.cc
+++ b/src/hegvd.cc
@@ -30,8 +30,8 @@ int64_t hegvd(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -93,8 +93,8 @@ int64_t hegvd(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/hegvx.cc
+++ b/src/hegvx.cc
@@ -36,9 +36,9 @@ int64_t hegvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -125,9 +125,9 @@ int64_t hegvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/herfs.cc
+++ b/src/herfs.cc
@@ -36,7 +36,7 @@ int64_t herfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -179,7 +179,7 @@ int64_t herfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/herfsx.cc
+++ b/src/herfsx.cc
@@ -44,8 +44,8 @@ int64_t herfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -387,8 +387,8 @@ int64_t herfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hesv.cc
+++ b/src/hesv.cc
@@ -30,7 +30,7 @@ int64_t hesv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -170,7 +170,7 @@ int64_t hesv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hesv_aa.cc
+++ b/src/hesv_aa.cc
@@ -32,7 +32,7 @@ int64_t hesv_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -164,7 +164,7 @@ int64_t hesv_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hesv_rk.cc
+++ b/src/hesv_rk.cc
@@ -33,7 +33,7 @@ int64_t hesv_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -212,7 +212,7 @@ int64_t hesv_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hesv_rook.cc
+++ b/src/hesv_rook.cc
@@ -32,7 +32,7 @@ int64_t hesv_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -97,7 +97,7 @@ int64_t hesv_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hesvx.cc
+++ b/src/hesvx.cc
@@ -37,8 +37,8 @@ int64_t hesvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -256,8 +256,8 @@ int64_t hesvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/heswapr.cc
+++ b/src/heswapr.cc
@@ -29,7 +29,7 @@ void heswapr(
         lapack_error_if( std::abs(i1) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(i2) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int i1_ = (lapack_int) i1;
@@ -84,7 +84,7 @@ void heswapr(
         lapack_error_if( std::abs(i1) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(i2) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int i1_ = (lapack_int) i1;

--- a/src/hetrd.cc
+++ b/src/hetrd.cc
@@ -29,7 +29,7 @@ int64_t hetrd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -187,7 +187,7 @@ int64_t hetrd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/hetrd_2stage.cc
+++ b/src/hetrd_2stage.cc
@@ -33,8 +33,8 @@ int64_t hetrd_2stage(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lhous2) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int lhous2_ = (lapack_int) lhous2;
@@ -202,8 +202,8 @@ int64_t hetrd_2stage(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lhous2) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int lhous2_ = (lapack_int) lhous2;

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -27,7 +27,7 @@ int64_t hetrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -192,7 +192,7 @@ int64_t hetrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hetrf_aa.cc
+++ b/src/hetrf_aa.cc
@@ -29,7 +29,7 @@ int64_t hetrf_aa(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -136,7 +136,7 @@ int64_t hetrf_aa(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hetrf_rk.cc
+++ b/src/hetrf_rk.cc
@@ -30,7 +30,7 @@ int64_t hetrf_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -246,7 +246,7 @@ int64_t hetrf_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hetrf_rook.cc
+++ b/src/hetrf_rook.cc
@@ -29,7 +29,7 @@ int64_t hetrf_rook(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -87,7 +87,7 @@ int64_t hetrf_rook(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hetri.cc
+++ b/src/hetri.cc
@@ -27,7 +27,7 @@ int64_t hetri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -111,7 +111,7 @@ int64_t hetri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hetri2.cc
+++ b/src/hetri2.cc
@@ -29,7 +29,7 @@ int64_t hetri2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -128,7 +128,7 @@ int64_t hetri2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hetri_rk.cc
+++ b/src/hetri_rk.cc
@@ -30,7 +30,7 @@ int64_t hetri_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -173,7 +173,7 @@ int64_t hetri_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/hetrs.cc
+++ b/src/hetrs.cc
@@ -30,7 +30,7 @@ int64_t hetrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -118,7 +118,7 @@ int64_t hetrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hetrs2.cc
+++ b/src/hetrs2.cc
@@ -32,7 +32,7 @@ int64_t hetrs2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -124,7 +124,7 @@ int64_t hetrs2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hetrs_aa.cc
+++ b/src/hetrs_aa.cc
@@ -32,7 +32,7 @@ int64_t hetrs_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -121,7 +121,7 @@ int64_t hetrs_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hetrs_rk.cc
+++ b/src/hetrs_rk.cc
@@ -33,7 +33,7 @@ int64_t hetrs_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -165,7 +165,7 @@ int64_t hetrs_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hetrs_rook.cc
+++ b/src/hetrs_rook.cc
@@ -32,7 +32,7 @@ int64_t hetrs_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -75,7 +75,7 @@ int64_t hetrs_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hfrk.cc
+++ b/src/hfrk.cc
@@ -26,9 +26,9 @@ void hfrk(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int lda_ = (lapack_int) lda;
@@ -52,9 +52,9 @@ void hfrk(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/hgeqz.cc
+++ b/src/hgeqz.cc
@@ -35,9 +35,9 @@ int64_t hgeqz(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -114,9 +114,9 @@ int64_t hgeqz(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -193,9 +193,9 @@ int64_t hgeqz(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -266,9 +266,9 @@ int64_t hgeqz(
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compq_ = job_comp2char( compq );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compq_ = to_char_comp( compq );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;

--- a/src/hpcon.cc
+++ b/src/hpcon.cc
@@ -26,7 +26,7 @@ int64_t hpcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -63,7 +63,7 @@ int64_t hpcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy

--- a/src/hpev.cc
+++ b/src/hpev.cc
@@ -27,8 +27,8 @@ int64_t hpev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -63,8 +63,8 @@ int64_t hpev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/hpevd.cc
+++ b/src/hpevd.cc
@@ -27,8 +27,8 @@ int64_t hpevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -86,8 +86,8 @@ int64_t hpevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/hpevx.cc
+++ b/src/hpevx.cc
@@ -31,9 +31,9 @@ int64_t hpevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -91,9 +91,9 @@ int64_t hpevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/hpgst.cc
+++ b/src/hpgst.cc
@@ -26,7 +26,7 @@ int64_t hpgst(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -53,7 +53,7 @@ int64_t hpgst(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/hpgv.cc
+++ b/src/hpgv.cc
@@ -30,8 +30,8 @@ int64_t hpgv(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -70,8 +70,8 @@ int64_t hpgv(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/hpgvd.cc
+++ b/src/hpgvd.cc
@@ -30,8 +30,8 @@ int64_t hpgvd(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -94,8 +94,8 @@ int64_t hpgvd(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/hpgvx.cc
+++ b/src/hpgvx.cc
@@ -34,9 +34,9 @@ int64_t hpgvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -98,9 +98,9 @@ int64_t hpgvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/hprfs.cc
+++ b/src/hprfs.cc
@@ -33,7 +33,7 @@ int64_t hprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -87,7 +87,7 @@ int64_t hprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/hpsv.cc
+++ b/src/hpsv.cc
@@ -28,7 +28,7 @@ int64_t hpsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -69,7 +69,7 @@ int64_t hpsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/hpsvx.cc
+++ b/src/hpsvx.cc
@@ -34,8 +34,8 @@ int64_t hpsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -93,8 +93,8 @@ int64_t hpsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/hptrd.cc
+++ b/src/hptrd.cc
@@ -26,7 +26,7 @@ int64_t hptrd(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -55,7 +55,7 @@ int64_t hptrd(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/hptrf.cc
+++ b/src/hptrf.cc
@@ -25,7 +25,7 @@ int64_t hptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -60,7 +60,7 @@ int64_t hptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy

--- a/src/hptri.cc
+++ b/src/hptri.cc
@@ -25,7 +25,7 @@ int64_t hptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -61,7 +61,7 @@ int64_t hptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy

--- a/src/hptrs.cc
+++ b/src/hptrs.cc
@@ -28,7 +28,7 @@ int64_t hptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -66,7 +66,7 @@ int64_t hptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/hseqr.cc
+++ b/src/hseqr.cc
@@ -31,8 +31,8 @@ int64_t hseqr(
         lapack_error_if( std::abs(ldh) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -97,8 +97,8 @@ int64_t hseqr(
         lapack_error_if( std::abs(ldh) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -163,8 +163,8 @@ int64_t hseqr(
         lapack_error_if( std::abs(ldh) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;
@@ -346,8 +346,8 @@ int64_t hseqr(
         lapack_error_if( std::abs(ldh) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobschur_ = jobschur2char( jobschur );
-    char compz_ = job_comp2char( compz );
+    char jobschur_ = to_char( jobschur );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
     lapack_int ihi_ = (lapack_int) ihi;

--- a/src/lacp2.cc
+++ b/src/lacp2.cc
@@ -27,7 +27,7 @@ void lacp2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -53,7 +53,7 @@ void lacp2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/lacpy.cc
+++ b/src/lacpy.cc
@@ -28,7 +28,7 @@ void lacpy(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -55,7 +55,7 @@ void lacpy(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -82,7 +82,7 @@ void lacpy(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -143,7 +143,7 @@ void lacpy(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/langb.cc
+++ b/src/langb.cc
@@ -28,7 +28,7 @@ float langb(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -60,7 +60,7 @@ double langb(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -92,7 +92,7 @@ float langb(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
@@ -158,7 +158,7 @@ double langb(
         lapack_error_if( std::abs(ku) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;

--- a/src/lange.cc
+++ b/src/lange.cc
@@ -27,7 +27,7 @@ float lange(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -57,7 +57,7 @@ double lange(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -87,7 +87,7 @@ float lange(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -144,7 +144,7 @@ double lange(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/langt.cc
+++ b/src/langt.cc
@@ -26,7 +26,7 @@ float langt(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_slangt(
@@ -49,7 +49,7 @@ double langt(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_dlangt(
@@ -72,7 +72,7 @@ float langt(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_clangt(
@@ -125,7 +125,7 @@ double langt(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_zlangt(

--- a/src/lanhb.cc
+++ b/src/lanhb.cc
@@ -27,8 +27,8 @@ float lanhb(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -101,8 +101,8 @@ double lanhb(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/lanhe.cc
+++ b/src/lanhe.cc
@@ -26,8 +26,8 @@ float lanhe(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 
@@ -100,8 +100,8 @@ double lanhe(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 

--- a/src/lanhp.cc
+++ b/src/lanhp.cc
@@ -25,8 +25,8 @@ float lanhp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
 
     // from docs
@@ -88,8 +88,8 @@ double lanhp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
 
     // from docs

--- a/src/lanhs.cc
+++ b/src/lanhs.cc
@@ -26,7 +26,7 @@ float lanhs(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 
@@ -54,7 +54,7 @@ double lanhs(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 
@@ -82,7 +82,7 @@ float lanhs(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 
@@ -136,7 +136,7 @@ double lanhs(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 

--- a/src/lanht.cc
+++ b/src/lanht.cc
@@ -25,7 +25,7 @@ float lanht(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_clanht(
@@ -74,7 +74,7 @@ double lanht(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_zlanht(

--- a/src/lansb.cc
+++ b/src/lansb.cc
@@ -27,8 +27,8 @@ float lansb(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -58,8 +58,8 @@ double lansb(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -89,8 +89,8 @@ float lansb(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -161,8 +161,8 @@ double lansb(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/lansp.cc
+++ b/src/lansp.cc
@@ -25,8 +25,8 @@ float lansp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
 
     // from docs
@@ -52,8 +52,8 @@ double lansp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
 
     // from docs
@@ -79,8 +79,8 @@ float lansp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
 
     // from docs
@@ -140,8 +140,8 @@ double lansp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
 
     // from docs

--- a/src/lanst.cc
+++ b/src/lanst.cc
@@ -25,7 +25,7 @@ float lanst(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_slanst( &norm_, &n_, D, E
@@ -71,7 +71,7 @@ double lanst(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
+    char norm_ = to_char( norm );
     lapack_int n_ = (lapack_int) n;
 
     return LAPACK_dlanst( &norm_, &n_, D, E

--- a/src/lansy.cc
+++ b/src/lansy.cc
@@ -26,8 +26,8 @@ float lansy(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 
@@ -55,8 +55,8 @@ double lansy(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 
@@ -84,8 +84,8 @@ float lansy(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 
@@ -155,8 +155,8 @@ double lansy(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
 

--- a/src/lantb.cc
+++ b/src/lantb.cc
@@ -27,9 +27,9 @@ float lantb(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -59,9 +59,9 @@ double lantb(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -91,9 +91,9 @@ float lantb(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -170,9 +170,9 @@ double lantb(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/lantp.cc
+++ b/src/lantp.cc
@@ -25,9 +25,9 @@ float lantp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
 
     // from docs
@@ -53,9 +53,9 @@ double lantp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
 
     // from docs
@@ -81,9 +81,9 @@ float lantp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
 
     // from docs
@@ -148,9 +148,9 @@ double lantp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
 
     // from docs

--- a/src/lantr.cc
+++ b/src/lantr.cc
@@ -35,9 +35,9 @@ float lantr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -75,9 +75,9 @@ double lantr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -115,9 +115,9 @@ float lantr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -212,9 +212,9 @@ double lantr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/larf.cc
+++ b/src/larf.cc
@@ -29,7 +29,7 @@ void larf(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;
@@ -63,7 +63,7 @@ void larf(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;
@@ -97,7 +97,7 @@ void larf(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;
@@ -176,7 +176,7 @@ void larf(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;

--- a/src/larfb.cc
+++ b/src/larfb.cc
@@ -34,10 +34,10 @@ void larfb(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -78,10 +78,10 @@ void larfb(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -123,10 +123,10 @@ void larfb(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -264,10 +264,10 @@ void larfb(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/larft.cc
+++ b/src/larft.cc
@@ -30,8 +30,8 @@ void larft(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
     }
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldv_ = (lapack_int) ldv;
@@ -61,8 +61,8 @@ void larft(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
     }
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldv_ = (lapack_int) ldv;
@@ -92,8 +92,8 @@ void larft(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
     }
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldv_ = (lapack_int) ldv;
@@ -215,8 +215,8 @@ void larft(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
     }
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int ldv_ = (lapack_int) ldv;

--- a/src/larfx.cc
+++ b/src/larfx.cc
@@ -28,7 +28,7 @@ void larfx(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -60,7 +60,7 @@ void larfx(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -92,7 +92,7 @@ void larfx(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -165,7 +165,7 @@ void larfx(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
+    char side_ = to_char( side );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;

--- a/src/larfy.cc
+++ b/src/larfy.cc
@@ -30,7 +30,7 @@ void larfy(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -59,7 +59,7 @@ void larfy(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -88,7 +88,7 @@ void larfy(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -160,7 +160,7 @@ void larfy(
         lapack_error_if( std::abs(incv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int incv_ = (lapack_int) incv;
     lapack_int ldc_ = (lapack_int) ldc;

--- a/src/lascl.cc
+++ b/src/lascl.cc
@@ -28,7 +28,7 @@ int64_t lascl(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
     lapack_int m_ = (lapack_int) m;
@@ -60,7 +60,7 @@ int64_t lascl(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
     lapack_int m_ = (lapack_int) m;
@@ -92,7 +92,7 @@ int64_t lascl(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
     lapack_int m_ = (lapack_int) m;
@@ -197,7 +197,7 @@ int64_t lascl(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int kl_ = (lapack_int) kl;
     lapack_int ku_ = (lapack_int) ku;
     lapack_int m_ = (lapack_int) m;

--- a/src/laset.cc
+++ b/src/laset.cc
@@ -26,7 +26,7 @@ void laset(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -49,7 +49,7 @@ void laset(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -72,7 +72,7 @@ void laset(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -134,7 +134,7 @@ void laset(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char matrixtype_ = matrixtype2char( matrixtype );
+    char matrixtype_ = to_char( matrixtype );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/lauum.cc
+++ b/src/lauum.cc
@@ -25,7 +25,7 @@ int64_t lauum(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -51,7 +51,7 @@ int64_t lauum(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -77,7 +77,7 @@ int64_t lauum(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -141,7 +141,7 @@ int64_t lauum(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/opgtr.cc
+++ b/src/opgtr.cc
@@ -27,7 +27,7 @@ int64_t opgtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldq_ = (lapack_int) ldq;
     lapack_int info_ = 0;
@@ -60,7 +60,7 @@ int64_t opgtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldq_ = (lapack_int) ldq;
     lapack_int info_ = 0;

--- a/src/opmtr.cc
+++ b/src/opmtr.cc
@@ -32,9 +32,9 @@ int64_t opmtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -76,9 +76,9 @@ int64_t opmtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;

--- a/src/orcsd2by1.cc
+++ b/src/orcsd2by1.cc
@@ -38,9 +38,9 @@ int64_t orcsd2by1(
         lapack_error_if( std::abs(ldu2) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv1t) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu1_ = job_csd2char( jobu1 );
-    char jobu2_ = job_csd2char( jobu2 );
-    char jobv1t_ = job_csd2char( jobv1t );
+    char jobu1_ = to_char_csd( jobu1 );
+    char jobu2_ = to_char_csd( jobu2 );
+    char jobv1t_ = to_char_csd( jobv1t );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int q_ = (lapack_int) q;
@@ -113,9 +113,9 @@ int64_t orcsd2by1(
         lapack_error_if( std::abs(ldu2) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldv1t) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu1_ = job_csd2char( jobu1 );
-    char jobu2_ = job_csd2char( jobu2 );
-    char jobv1t_ = job_csd2char( jobv1t );
+    char jobu1_ = to_char_csd( jobu1 );
+    char jobu2_ = to_char_csd( jobu2 );
+    char jobv1t_ = to_char_csd( jobv1t );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int q_ = (lapack_int) q;

--- a/src/orgbr.cc
+++ b/src/orgbr.cc
@@ -29,7 +29,7 @@ int64_t orgbr(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -80,7 +80,7 @@ int64_t orgbr(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/orgtr.cc
+++ b/src/orgtr.cc
@@ -27,7 +27,7 @@ int64_t orgtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -74,7 +74,7 @@ int64_t orgtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/orhr_col.cc
+++ b/src/orhr_col.cc
@@ -40,6 +40,9 @@ int64_t orhr_col(
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int info_ = 0;
 
+    // Work around bug in LAPACK <= 3.12. See https://github.com/Reference-LAPACK/lapack/pull/1018
+    nb_ = min( nb_, n );
+
     LAPACK_sorhr_col(
         &m_, &n_, &nb_,
         A, &lda_,
@@ -158,6 +161,9 @@ int64_t orhr_col(
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int info_ = 0;
+
+    // Work around bug in LAPACK <= 3.12. See https://github.com/Reference-LAPACK/lapack/pull/1018
+    nb_ = min( nb_, n );
 
     LAPACK_dorhr_col(
         &m_, &n_, &nb_,

--- a/src/ormbr.cc
+++ b/src/ormbr.cc
@@ -35,9 +35,9 @@ int64_t ormbr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char vect_ = to_char( vect );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -97,9 +97,9 @@ int64_t ormbr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char vect_ = to_char( vect );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/ormhr.cc
+++ b/src/ormhr.cc
@@ -35,8 +35,8 @@ int64_t ormhr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
@@ -96,8 +96,8 @@ int64_t ormhr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;

--- a/src/ormlq.cc
+++ b/src/ormlq.cc
@@ -35,8 +35,8 @@ int64_t ormlq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -96,8 +96,8 @@ int64_t ormlq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/ormql.cc
+++ b/src/ormql.cc
@@ -35,8 +35,8 @@ int64_t ormql(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -96,8 +96,8 @@ int64_t ormql(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/ormqr.cc
+++ b/src/ormqr.cc
@@ -35,8 +35,8 @@ int64_t ormqr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -96,8 +96,8 @@ int64_t ormqr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/ormrq.cc
+++ b/src/ormrq.cc
@@ -35,8 +35,8 @@ int64_t ormrq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -96,8 +96,8 @@ int64_t ormrq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/ormrz.cc
+++ b/src/ormrz.cc
@@ -35,8 +35,8 @@ int64_t ormrz(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -96,8 +96,8 @@ int64_t ormrz(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/ormtr.cc
+++ b/src/ormtr.cc
@@ -34,9 +34,9 @@ int64_t ormtr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -94,9 +94,9 @@ int64_t ormtr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/pbcon.cc
+++ b/src/pbcon.cc
@@ -28,7 +28,7 @@ int64_t pbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -63,7 +63,7 @@ int64_t pbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -98,7 +98,7 @@ int64_t pbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -178,7 +178,7 @@ int64_t pbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/pbequ.cc
+++ b/src/pbequ.cc
@@ -29,7 +29,7 @@ int64_t pbequ(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -61,7 +61,7 @@ int64_t pbequ(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -93,7 +93,7 @@ int64_t pbequ(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -177,7 +177,7 @@ int64_t pbequ(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/pbrfs.cc
+++ b/src/pbrfs.cc
@@ -36,7 +36,7 @@ int64_t pbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -88,7 +88,7 @@ int64_t pbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -140,7 +140,7 @@ int64_t pbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -270,7 +270,7 @@ int64_t pbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;

--- a/src/pbstf.cc
+++ b/src/pbstf.cc
@@ -26,7 +26,7 @@ int64_t pbstf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -54,7 +54,7 @@ int64_t pbstf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -82,7 +82,7 @@ int64_t pbstf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -206,7 +206,7 @@ int64_t pbstf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/pbsv.cc
+++ b/src/pbsv.cc
@@ -29,7 +29,7 @@ int64_t pbsv(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -63,7 +63,7 @@ int64_t pbsv(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -97,7 +97,7 @@ int64_t pbsv(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -219,7 +219,7 @@ int64_t pbsv(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;

--- a/src/pbsvx.cc
+++ b/src/pbsvx.cc
@@ -39,9 +39,9 @@ int64_t pbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -71,7 +71,7 @@ int64_t pbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -99,9 +99,9 @@ int64_t pbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -131,7 +131,7 @@ int64_t pbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -159,9 +159,9 @@ int64_t pbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -191,7 +191,7 @@ int64_t pbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -417,9 +417,9 @@ int64_t pbsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -449,7 +449,7 @@ int64_t pbsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -26,7 +26,7 @@ int64_t pbtrf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -54,7 +54,7 @@ int64_t pbtrf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -82,7 +82,7 @@ int64_t pbtrf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -176,7 +176,7 @@ int64_t pbtrf(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/pbtrs.cc
+++ b/src/pbtrs.cc
@@ -29,7 +29,7 @@ int64_t pbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -63,7 +63,7 @@ int64_t pbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -97,7 +97,7 @@ int64_t pbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -176,7 +176,7 @@ int64_t pbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;

--- a/src/pftrf.cc
+++ b/src/pftrf.cc
@@ -23,8 +23,8 @@ int64_t pftrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -47,8 +47,8 @@ int64_t pftrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -71,8 +71,8 @@ int64_t pftrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -95,8 +95,8 @@ int64_t pftrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/pftri.cc
+++ b/src/pftri.cc
@@ -23,8 +23,8 @@ int64_t pftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -47,8 +47,8 @@ int64_t pftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -71,8 +71,8 @@ int64_t pftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -95,8 +95,8 @@ int64_t pftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/pftrs.cc
+++ b/src/pftrs.cc
@@ -26,8 +26,8 @@ int64_t pftrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -56,8 +56,8 @@ int64_t pftrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -86,8 +86,8 @@ int64_t pftrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -116,8 +116,8 @@ int64_t pftrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/pocon.cc
+++ b/src/pocon.cc
@@ -27,7 +27,7 @@ int64_t pocon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -60,7 +60,7 @@ int64_t pocon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -93,7 +93,7 @@ int64_t pocon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -161,7 +161,7 @@ int64_t pocon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/porfs.cc
+++ b/src/porfs.cc
@@ -35,7 +35,7 @@ int64_t porfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -85,7 +85,7 @@ int64_t porfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -135,7 +135,7 @@ int64_t porfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -262,7 +262,7 @@ int64_t porfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/porfsx.cc
+++ b/src/porfsx.cc
@@ -43,8 +43,8 @@ int64_t porfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -105,8 +105,8 @@ int64_t porfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -167,8 +167,8 @@ int64_t porfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -489,8 +489,8 @@ int64_t porfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/posv.cc
+++ b/src/posv.cc
@@ -29,7 +29,7 @@ int64_t posv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -61,7 +61,7 @@ int64_t posv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -93,7 +93,7 @@ int64_t posv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -184,7 +184,7 @@ int64_t posv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -218,7 +218,7 @@ int64_t posv(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -262,7 +262,7 @@ int64_t posv(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/posvx.cc
+++ b/src/posvx.cc
@@ -38,9 +38,9 @@ int64_t posvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -69,7 +69,7 @@ int64_t posvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -96,9 +96,9 @@ int64_t posvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -127,7 +127,7 @@ int64_t posvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -154,9 +154,9 @@ int64_t posvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -185,7 +185,7 @@ int64_t posvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -381,9 +381,9 @@ int64_t posvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -412,7 +412,7 @@ int64_t posvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 

--- a/src/potf2.cc
+++ b/src/potf2.cc
@@ -25,7 +25,7 @@ int64_t potf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -51,7 +51,7 @@ int64_t potf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -77,7 +77,7 @@ int64_t potf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -148,7 +148,7 @@ int64_t potf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -25,7 +25,7 @@ int64_t potrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -51,7 +51,7 @@ int64_t potrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -77,7 +77,7 @@ int64_t potrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -148,7 +148,7 @@ int64_t potrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/potrf2.cc
+++ b/src/potrf2.cc
@@ -27,7 +27,7 @@ int64_t potrf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -53,7 +53,7 @@ int64_t potrf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -79,7 +79,7 @@ int64_t potrf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -162,7 +162,7 @@ int64_t potrf2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/potri.cc
+++ b/src/potri.cc
@@ -25,7 +25,7 @@ int64_t potri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -51,7 +51,7 @@ int64_t potri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -77,7 +77,7 @@ int64_t potri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -132,7 +132,7 @@ int64_t potri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/potrs.cc
+++ b/src/potrs.cc
@@ -28,7 +28,7 @@ int64_t potrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -60,7 +60,7 @@ int64_t potrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -92,7 +92,7 @@ int64_t potrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -160,7 +160,7 @@ int64_t potrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/ppcon.cc
+++ b/src/ppcon.cc
@@ -26,7 +26,7 @@ int64_t ppcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -57,7 +57,7 @@ int64_t ppcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -88,7 +88,7 @@ int64_t ppcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -156,7 +156,7 @@ int64_t ppcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/ppequ.cc
+++ b/src/ppequ.cc
@@ -27,7 +27,7 @@ int64_t ppequ(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -55,7 +55,7 @@ int64_t ppequ(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -83,7 +83,7 @@ int64_t ppequ(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -155,7 +155,7 @@ int64_t ppequ(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/pprfs.cc
+++ b/src/pprfs.cc
@@ -33,7 +33,7 @@ int64_t pprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -79,7 +79,7 @@ int64_t pprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -125,7 +125,7 @@ int64_t pprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -239,7 +239,7 @@ int64_t pprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/ppsv.cc
+++ b/src/ppsv.cc
@@ -27,7 +27,7 @@ int64_t ppsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -57,7 +57,7 @@ int64_t ppsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -87,7 +87,7 @@ int64_t ppsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -190,7 +190,7 @@ int64_t ppsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/ppsvx.cc
+++ b/src/ppsvx.cc
@@ -36,9 +36,9 @@ int64_t ppsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -65,7 +65,7 @@ int64_t ppsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -90,9 +90,9 @@ int64_t ppsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -119,7 +119,7 @@ int64_t ppsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -144,9 +144,9 @@ int64_t ppsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -173,7 +173,7 @@ int64_t ppsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 
@@ -375,9 +375,9 @@ int64_t ppsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( *equed );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( *equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -404,7 +404,7 @@ int64_t ppsvx(
     if (info_ < 0) {
         throw Error();
     }
-    *equed = char2equed( equed_ );
+    from_string( std::string( 1, equed_ ), equed );
     return info_;
 }
 

--- a/src/pptrf.cc
+++ b/src/pptrf.cc
@@ -24,7 +24,7 @@ int64_t pptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -48,7 +48,7 @@ int64_t pptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -72,7 +72,7 @@ int64_t pptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -150,7 +150,7 @@ int64_t pptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/pptri.cc
+++ b/src/pptri.cc
@@ -24,7 +24,7 @@ int64_t pptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -48,7 +48,7 @@ int64_t pptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -72,7 +72,7 @@ int64_t pptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -126,7 +126,7 @@ int64_t pptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/pptrs.cc
+++ b/src/pptrs.cc
@@ -27,7 +27,7 @@ int64_t pptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -57,7 +57,7 @@ int64_t pptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -87,7 +87,7 @@ int64_t pptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -154,7 +154,7 @@ int64_t pptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/pstrf.cc
+++ b/src/pstrf.cc
@@ -27,7 +27,7 @@ int64_t pstrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -71,7 +71,7 @@ int64_t pstrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -115,7 +115,7 @@ int64_t pstrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -159,7 +159,7 @@ int64_t pstrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/pteqr.cc
+++ b/src/pteqr.cc
@@ -27,7 +27,7 @@ int64_t pteqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -60,7 +60,7 @@ int64_t pteqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -93,7 +93,7 @@ int64_t pteqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -126,7 +126,7 @@ int64_t pteqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/ptrfs.cc
+++ b/src/ptrfs.cc
@@ -127,7 +127,7 @@ int64_t ptrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -253,7 +253,7 @@ int64_t ptrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/ptsvx.cc
+++ b/src/ptsvx.cc
@@ -36,7 +36,7 @@ int64_t ptsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
+    char fact_ = to_char( fact );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -85,7 +85,7 @@ int64_t ptsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
+    char fact_ = to_char( fact );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -134,7 +134,7 @@ int64_t ptsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
+    char fact_ = to_char( fact );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -288,7 +288,7 @@ int64_t ptsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
+    char fact_ = to_char( fact );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/pttrs.cc
+++ b/src/pttrs.cc
@@ -88,7 +88,7 @@ int64_t pttrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -170,7 +170,7 @@ int64_t pttrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/sbev.cc
+++ b/src/sbev.cc
@@ -29,8 +29,8 @@ int64_t sbev(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -67,8 +67,8 @@ int64_t sbev(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/sbev_2stage.cc
+++ b/src/sbev_2stage.cc
@@ -31,8 +31,8 @@ int64_t sbev_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -84,8 +84,8 @@ int64_t sbev_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/sbevd.cc
+++ b/src/sbevd.cc
@@ -29,8 +29,8 @@ int64_t sbevd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -87,8 +87,8 @@ int64_t sbevd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/sbevd_2stage.cc
+++ b/src/sbevd_2stage.cc
@@ -31,8 +31,8 @@ int64_t sbevd_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -89,8 +89,8 @@ int64_t sbevd_2stage(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/sbevx.cc
+++ b/src/sbevx.cc
@@ -35,9 +35,9 @@ int64_t sbevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -101,9 +101,9 @@ int64_t sbevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/sbevx_2stage.cc
+++ b/src/sbevx_2stage.cc
@@ -37,9 +37,9 @@ int64_t sbevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -122,9 +122,9 @@ int64_t sbevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/sbgst.cc
+++ b/src/sbgst.cc
@@ -31,8 +31,8 @@ int64_t sbgst(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -73,8 +73,8 @@ int64_t sbgst(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/sbgv.cc
+++ b/src/sbgv.cc
@@ -32,8 +32,8 @@ int64_t sbgv(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -76,8 +76,8 @@ int64_t sbgv(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/sbgvd.cc
+++ b/src/sbgvd.cc
@@ -32,8 +32,8 @@ int64_t sbgvd(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -100,8 +100,8 @@ int64_t sbgvd(
         lapack_error_if( std::abs(ldbb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/sbgvx.cc
+++ b/src/sbgvx.cc
@@ -38,9 +38,9 @@ int64_t sbgvx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;
@@ -110,9 +110,9 @@ int64_t sbgvx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ka_ = (lapack_int) ka;
     lapack_int kb_ = (lapack_int) kb;

--- a/src/sbtrd.cc
+++ b/src/sbtrd.cc
@@ -30,8 +30,8 @@ int64_t sbtrd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -70,8 +70,8 @@ int64_t sbtrd(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/sfrk.cc
+++ b/src/sfrk.cc
@@ -26,9 +26,9 @@ void sfrk(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int lda_ = (lapack_int) lda;
@@ -52,9 +52,9 @@ void sfrk(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/spcon.cc
+++ b/src/spcon.cc
@@ -26,7 +26,7 @@ int64_t spcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -65,7 +65,7 @@ int64_t spcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -104,7 +104,7 @@ int64_t spcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -141,7 +141,7 @@ int64_t spcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy

--- a/src/spev.cc
+++ b/src/spev.cc
@@ -27,8 +27,8 @@ int64_t spev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -61,8 +61,8 @@ int64_t spev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/spevd.cc
+++ b/src/spevd.cc
@@ -27,8 +27,8 @@ int64_t spevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -81,8 +81,8 @@ int64_t spevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/spevx.cc
+++ b/src/spevx.cc
@@ -31,9 +31,9 @@ int64_t spevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -89,9 +89,9 @@ int64_t spevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/spgst.cc
+++ b/src/spgst.cc
@@ -26,7 +26,7 @@ int64_t spgst(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -53,7 +53,7 @@ int64_t spgst(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/spgv.cc
+++ b/src/spgv.cc
@@ -30,8 +30,8 @@ int64_t spgv(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -68,8 +68,8 @@ int64_t spgv(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/spgvd.cc
+++ b/src/spgvd.cc
@@ -30,8 +30,8 @@ int64_t spgvd(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -89,8 +89,8 @@ int64_t spgvd(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/spgvx.cc
+++ b/src/spgvx.cc
@@ -34,9 +34,9 @@ int64_t spgvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -96,9 +96,9 @@ int64_t spgvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/sprfs.cc
+++ b/src/sprfs.cc
@@ -33,7 +33,7 @@ int64_t sprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -87,7 +87,7 @@ int64_t sprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -141,7 +141,7 @@ int64_t sprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -195,7 +195,7 @@ int64_t sprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/spsv.cc
+++ b/src/spsv.cc
@@ -28,7 +28,7 @@ int64_t spsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -69,7 +69,7 @@ int64_t spsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -110,7 +110,7 @@ int64_t spsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -151,7 +151,7 @@ int64_t spsv(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/spsvx.cc
+++ b/src/spsvx.cc
@@ -34,8 +34,8 @@ int64_t spsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -93,8 +93,8 @@ int64_t spsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -152,8 +152,8 @@ int64_t spsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -211,8 +211,8 @@ int64_t spsvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/sptrd.cc
+++ b/src/sptrd.cc
@@ -26,7 +26,7 @@ int64_t sptrd(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -55,7 +55,7 @@ int64_t sptrd(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/sptrf.cc
+++ b/src/sptrf.cc
@@ -25,7 +25,7 @@ int64_t sptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -60,7 +60,7 @@ int64_t sptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -95,7 +95,7 @@ int64_t sptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -130,7 +130,7 @@ int64_t sptrf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy

--- a/src/sptri.cc
+++ b/src/sptri.cc
@@ -25,7 +25,7 @@ int64_t sptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -61,7 +61,7 @@ int64_t sptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -97,7 +97,7 @@ int64_t sptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy
@@ -133,7 +133,7 @@ int64_t sptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     #ifndef LAPACK_ILP64
         // 32-bit copy

--- a/src/sptrs.cc
+++ b/src/sptrs.cc
@@ -28,7 +28,7 @@ int64_t sptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -66,7 +66,7 @@ int64_t sptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -104,7 +104,7 @@ int64_t sptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64
@@ -142,7 +142,7 @@ int64_t sptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     #ifndef LAPACK_ILP64

--- a/src/stedc.cc
+++ b/src/stedc.cc
@@ -27,7 +27,7 @@ int64_t stedc(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -80,7 +80,7 @@ int64_t stedc(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -133,7 +133,7 @@ int64_t stedc(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -191,7 +191,7 @@ int64_t stedc(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/stegr.cc
+++ b/src/stegr.cc
@@ -32,8 +32,8 @@ int64_t stegr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -109,8 +109,8 @@ int64_t stegr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -186,8 +186,8 @@ int64_t stegr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -263,8 +263,8 @@ int64_t stegr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/stemr.cc
+++ b/src/stemr.cc
@@ -34,8 +34,8 @@ int64_t stemr(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nzc) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -116,8 +116,8 @@ int64_t stemr(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nzc) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -198,8 +198,8 @@ int64_t stemr(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nzc) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -280,8 +280,8 @@ int64_t stemr(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nzc) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/steqr.cc
+++ b/src/steqr.cc
@@ -27,7 +27,7 @@ int64_t steqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -60,7 +60,7 @@ int64_t steqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -93,7 +93,7 @@ int64_t steqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -126,7 +126,7 @@ int64_t steqr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char compz_ = job_comp2char( compz );
+    char compz_ = to_char_comp( compz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/stev.cc
+++ b/src/stev.cc
@@ -27,7 +27,7 @@ int64_t stev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -60,7 +60,7 @@ int64_t stev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/stevd.cc
+++ b/src/stevd.cc
@@ -27,7 +27,7 @@ int64_t stevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;
@@ -80,7 +80,7 @@ int64_t stevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
+    char jobz_ = to_char( jobz );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldz_ = (lapack_int) ldz;
     lapack_int info_ = 0;

--- a/src/stevr.cc
+++ b/src/stevr.cc
@@ -32,8 +32,8 @@ int64_t stevr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -109,8 +109,8 @@ int64_t stevr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/stevx.cc
+++ b/src/stevx.cc
@@ -32,8 +32,8 @@ int64_t stevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;
@@ -91,8 +91,8 @@ int64_t stevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
     lapack_int n_ = (lapack_int) n;
     lapack_int il_ = (lapack_int) il;
     lapack_int iu_ = (lapack_int) iu;

--- a/src/sycon.cc
+++ b/src/sycon.cc
@@ -28,7 +28,7 @@ int64_t sycon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -70,7 +70,7 @@ int64_t sycon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -112,7 +112,7 @@ int64_t sycon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -196,7 +196,7 @@ int64_t sycon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sycon_rk.cc
+++ b/src/sycon_rk.cc
@@ -31,7 +31,7 @@ int64_t sycon_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -75,7 +75,7 @@ int64_t sycon_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -119,7 +119,7 @@ int64_t sycon_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -238,7 +238,7 @@ int64_t sycon_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/syequb.cc
+++ b/src/syequb.cc
@@ -29,7 +29,7 @@ int64_t syequb(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -63,7 +63,7 @@ int64_t syequb(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -97,7 +97,7 @@ int64_t syequb(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -176,7 +176,7 @@ int64_t syequb(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/syev.cc
+++ b/src/syev.cc
@@ -27,8 +27,8 @@ int64_t syev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -75,8 +75,8 @@ int64_t syev(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/syev_2stage.cc
+++ b/src/syev_2stage.cc
@@ -29,8 +29,8 @@ int64_t syev_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -77,8 +77,8 @@ int64_t syev_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/syevd.cc
+++ b/src/syevd.cc
@@ -27,8 +27,8 @@ int64_t syevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -80,8 +80,8 @@ int64_t syevd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/syevd_2stage.cc
+++ b/src/syevd_2stage.cc
@@ -29,8 +29,8 @@ int64_t syevd_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -82,8 +82,8 @@ int64_t syevd_2stage(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/syevr.cc
+++ b/src/syevr.cc
@@ -33,9 +33,9 @@ int64_t syevr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -112,9 +112,9 @@ int64_t syevr(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/syevr_2stage.cc
+++ b/src/syevr_2stage.cc
@@ -35,9 +35,9 @@ int64_t syevr_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -114,9 +114,9 @@ int64_t syevr_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/syevx.cc
+++ b/src/syevx.cc
@@ -33,9 +33,9 @@ int64_t syevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -113,9 +113,9 @@ int64_t syevx(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/syevx_2stage.cc
+++ b/src/syevx_2stage.cc
@@ -35,9 +35,9 @@ int64_t syevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;
@@ -115,9 +115,9 @@ int64_t syevx_2stage(
         lapack_error_if( std::abs(iu) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int il_ = (lapack_int) il;

--- a/src/sygst.cc
+++ b/src/sygst.cc
@@ -28,7 +28,7 @@ int64_t sygst(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -59,7 +59,7 @@ int64_t sygst(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/sygv.cc
+++ b/src/sygv.cc
@@ -30,8 +30,8 @@ int64_t sygv(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -83,8 +83,8 @@ int64_t sygv(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/sygv_2stage.cc
+++ b/src/sygv_2stage.cc
@@ -32,8 +32,8 @@ int64_t sygv_2stage(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -85,8 +85,8 @@ int64_t sygv_2stage(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/sygvd.cc
+++ b/src/sygvd.cc
@@ -30,8 +30,8 @@ int64_t sygvd(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -88,8 +88,8 @@ int64_t sygvd(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/sygvx.cc
+++ b/src/sygvx.cc
@@ -36,9 +36,9 @@ int64_t sygvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -121,9 +121,9 @@ int64_t sygvx(
         lapack_error_if( std::abs(ldz) > std::numeric_limits<lapack_int>::max() );
     }
     lapack_int itype_ = (lapack_int) itype;
-    char jobz_ = job2char( jobz );
-    char range_ = range2char( range );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char range_ = to_char( range );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/symv.cc
+++ b/src/symv.cc
@@ -56,7 +56,7 @@ void symv(
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
 
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     LAPACK_csymv( &uplo_, &n_,
                 (lapack_complex_float*) &alpha,
                 (lapack_complex_float*) A, &lda_,
@@ -106,7 +106,7 @@ void symv(
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
 
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     LAPACK_zsymv( &uplo_, &n_,
                 (lapack_complex_double*) &alpha,
                 (lapack_complex_double*) A, &lda_,

--- a/src/syr.cc
+++ b/src/syr.cc
@@ -49,7 +49,7 @@ void syr(
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
 
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     LAPACK_csyr( &uplo_, &n_,
                  (lapack_complex_float*) &alpha,
                  (lapack_complex_float*) x, &incx_,
@@ -92,7 +92,7 @@ void syr(
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
     }
 
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     LAPACK_zsyr( &uplo_, &n_,
                  (lapack_complex_double*) &alpha,
                  (lapack_complex_double*) x, &incx_,

--- a/src/syrfs.cc
+++ b/src/syrfs.cc
@@ -36,7 +36,7 @@ int64_t syrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -95,7 +95,7 @@ int64_t syrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -154,7 +154,7 @@ int64_t syrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -297,7 +297,7 @@ int64_t syrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/syrfsx.cc
+++ b/src/syrfsx.cc
@@ -44,8 +44,8 @@ int64_t syrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -115,8 +115,8 @@ int64_t syrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -186,8 +186,8 @@ int64_t syrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -529,8 +529,8 @@ int64_t syrfsx(
         lapack_error_if( std::abs(n_err_bnds) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(nparams) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char equed_ = equed2char( equed );
+    char uplo_ = to_char( uplo );
+    char equed_ = to_char( equed );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sysv.cc
+++ b/src/sysv.cc
@@ -30,7 +30,7 @@ int64_t sysv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -93,7 +93,7 @@ int64_t sysv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -156,7 +156,7 @@ int64_t sysv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -298,7 +298,7 @@ int64_t sysv(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sysv_aa.cc
+++ b/src/sysv_aa.cc
@@ -32,7 +32,7 @@ int64_t sysv_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -121,7 +121,7 @@ int64_t sysv_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -211,7 +211,7 @@ int64_t sysv_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -369,7 +369,7 @@ int64_t sysv_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sysv_rk.cc
+++ b/src/sysv_rk.cc
@@ -33,7 +33,7 @@ int64_t sysv_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -99,7 +99,7 @@ int64_t sysv_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -165,7 +165,7 @@ int64_t sysv_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -344,7 +344,7 @@ int64_t sysv_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sysv_rook.cc
+++ b/src/sysv_rook.cc
@@ -32,7 +32,7 @@ int64_t sysv_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -95,7 +95,7 @@ int64_t sysv_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -158,7 +158,7 @@ int64_t sysv_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -223,7 +223,7 @@ int64_t sysv_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sysvx.cc
+++ b/src/sysvx.cc
@@ -37,8 +37,8 @@ int64_t sysvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -122,8 +122,8 @@ int64_t sysvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -207,8 +207,8 @@ int64_t sysvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -427,8 +427,8 @@ int64_t sysvx(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char fact_ = factored2char( fact );
-    char uplo_ = uplo2char( uplo );
+    char fact_ = to_char( fact );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/syswapr.cc
+++ b/src/syswapr.cc
@@ -29,7 +29,7 @@ void syswapr(
         lapack_error_if( std::abs(i1) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(i2) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int i1_ = (lapack_int) i1;
@@ -54,7 +54,7 @@ void syswapr(
         lapack_error_if( std::abs(i1) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(i2) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int i1_ = (lapack_int) i1;
@@ -79,7 +79,7 @@ void syswapr(
         lapack_error_if( std::abs(i1) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(i2) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int i1_ = (lapack_int) i1;
@@ -134,7 +134,7 @@ void syswapr(
         lapack_error_if( std::abs(i1) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(i2) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int i1_ = (lapack_int) i1;

--- a/src/sytrd.cc
+++ b/src/sytrd.cc
@@ -29,7 +29,7 @@ int64_t sytrd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -82,7 +82,7 @@ int64_t sytrd(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/sytrd_2stage.cc
+++ b/src/sytrd_2stage.cc
@@ -33,8 +33,8 @@ int64_t sytrd_2stage(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lhous2) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int lhous2_ = (lapack_int) lhous2;
@@ -92,8 +92,8 @@ int64_t sytrd_2stage(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lhous2) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobz_ = job2char( jobz );
-    char uplo_ = uplo2char( uplo );
+    char jobz_ = to_char( jobz );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int lhous2_ = (lapack_int) lhous2;

--- a/src/sytrf.cc
+++ b/src/sytrf.cc
@@ -27,7 +27,7 @@ int64_t sytrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -83,7 +83,7 @@ int64_t sytrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -139,7 +139,7 @@ int64_t sytrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -304,7 +304,7 @@ int64_t sytrf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sytrf_aa.cc
+++ b/src/sytrf_aa.cc
@@ -29,7 +29,7 @@ int64_t sytrf_aa(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -85,7 +85,7 @@ int64_t sytrf_aa(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -141,7 +141,7 @@ int64_t sytrf_aa(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -248,7 +248,7 @@ int64_t sytrf_aa(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sytrf_rk.cc
+++ b/src/sytrf_rk.cc
@@ -30,7 +30,7 @@ int64_t sytrf_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -89,7 +89,7 @@ int64_t sytrf_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -148,7 +148,7 @@ int64_t sytrf_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -364,7 +364,7 @@ int64_t sytrf_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sytrf_rook.cc
+++ b/src/sytrf_rook.cc
@@ -29,7 +29,7 @@ int64_t sytrf_rook(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -85,7 +85,7 @@ int64_t sytrf_rook(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -141,7 +141,7 @@ int64_t sytrf_rook(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -199,7 +199,7 @@ int64_t sytrf_rook(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sytri.cc
+++ b/src/sytri.cc
@@ -27,7 +27,7 @@ int64_t sytri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -66,7 +66,7 @@ int64_t sytri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -105,7 +105,7 @@ int64_t sytri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -189,7 +189,7 @@ int64_t sytri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sytri2.cc
+++ b/src/sytri2.cc
@@ -29,7 +29,7 @@ int64_t sytri2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -82,7 +82,7 @@ int64_t sytri2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -134,7 +134,7 @@ int64_t sytri2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -233,7 +233,7 @@ int64_t sytri2(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sytri_rk.cc
+++ b/src/sytri_rk.cc
@@ -30,7 +30,7 @@ int64_t sytri_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -86,7 +86,7 @@ int64_t sytri_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -142,7 +142,7 @@ int64_t sytri_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64
@@ -284,7 +284,7 @@ int64_t sytri_rk(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     #ifndef LAPACK_ILP64

--- a/src/sytrs.cc
+++ b/src/sytrs.cc
@@ -30,7 +30,7 @@ int64_t sytrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -71,7 +71,7 @@ int64_t sytrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -112,7 +112,7 @@ int64_t sytrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -200,7 +200,7 @@ int64_t sytrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sytrs2.cc
+++ b/src/sytrs2.cc
@@ -32,7 +32,7 @@ int64_t sytrs2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -77,7 +77,7 @@ int64_t sytrs2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -122,7 +122,7 @@ int64_t sytrs2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -219,7 +219,7 @@ int64_t sytrs2(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sytrs_aa.cc
+++ b/src/sytrs_aa.cc
@@ -32,7 +32,7 @@ int64_t sytrs_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -78,7 +78,7 @@ int64_t sytrs_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -124,7 +124,7 @@ int64_t sytrs_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -213,7 +213,7 @@ int64_t sytrs_aa(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sytrs_rk.cc
+++ b/src/sytrs_rk.cc
@@ -33,7 +33,7 @@ int64_t sytrs_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -76,7 +76,7 @@ int64_t sytrs_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -119,7 +119,7 @@ int64_t sytrs_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -246,7 +246,7 @@ int64_t sytrs_rk(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/sytrs_rook.cc
+++ b/src/sytrs_rook.cc
@@ -32,7 +32,7 @@ int64_t sytrs_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -73,7 +73,7 @@ int64_t sytrs_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -114,7 +114,7 @@ int64_t sytrs_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -157,7 +157,7 @@ int64_t sytrs_rook(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/tbcon.cc
+++ b/src/tbcon.cc
@@ -27,9 +27,9 @@ int64_t tbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -63,9 +63,9 @@ int64_t tbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -99,9 +99,9 @@ int64_t tbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;
@@ -135,9 +135,9 @@ int64_t tbcon(
         lapack_error_if( std::abs(kd) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int ldab_ = (lapack_int) ldab;

--- a/src/tbrfs.cc
+++ b/src/tbrfs.cc
@@ -33,9 +33,9 @@ int64_t tbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -82,9 +82,9 @@ int64_t tbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -131,9 +131,9 @@ int64_t tbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -180,9 +180,9 @@ int64_t tbrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;

--- a/src/tbtrs.cc
+++ b/src/tbtrs.cc
@@ -28,9 +28,9 @@ int64_t tbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -63,9 +63,9 @@ int64_t tbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -98,9 +98,9 @@ int64_t tbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;
@@ -133,9 +133,9 @@ int64_t tbtrs(
         lapack_error_if( std::abs(ldab) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int kd_ = (lapack_int) kd;
     lapack_int nrhs_ = (lapack_int) nrhs;

--- a/src/tfsm.cc
+++ b/src/tfsm.cc
@@ -26,11 +26,11 @@ void tfsm(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -54,11 +54,11 @@ void tfsm(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -82,11 +82,11 @@ void tfsm(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -111,11 +111,11 @@ void tfsm(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/tftri.cc
+++ b/src/tftri.cc
@@ -23,9 +23,9 @@ int64_t tftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -48,9 +48,9 @@ int64_t tftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -73,9 +73,9 @@ int64_t tftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -98,9 +98,9 @@ int64_t tftri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/tfttp.cc
+++ b/src/tfttp.cc
@@ -24,8 +24,8 @@ int64_t tfttp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -50,8 +50,8 @@ int64_t tfttp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -76,8 +76,8 @@ int64_t tfttp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -102,8 +102,8 @@ int64_t tfttp(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/tfttr.cc
+++ b/src/tfttr.cc
@@ -25,8 +25,8 @@ int64_t tfttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -53,8 +53,8 @@ int64_t tfttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -81,8 +81,8 @@ int64_t tfttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -109,8 +109,8 @@ int64_t tfttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/tgsja.cc
+++ b/src/tgsja.cc
@@ -40,9 +40,9 @@ int64_t tgsja(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job_compu2char( jobu );
-    char jobv_ = job_comp2char( jobv );
-    char jobq_ = job_compq2char( jobq );
+    char jobu_ = to_char_compu( jobu );
+    char jobv_ = to_char_comp( jobv );
+    char jobq_ = to_char_compq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;
@@ -102,9 +102,9 @@ int64_t tgsja(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job_compu2char( jobu );
-    char jobv_ = job_comp2char( jobv );
-    char jobq_ = job_compq2char( jobq );
+    char jobu_ = to_char_compu( jobu );
+    char jobv_ = to_char_comp( jobv );
+    char jobq_ = to_char_compq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;
@@ -164,9 +164,9 @@ int64_t tgsja(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job_compu2char( jobu );
-    char jobv_ = job_comp2char( jobv );
-    char jobq_ = job_compq2char( jobq );
+    char jobu_ = to_char_compu( jobu );
+    char jobv_ = to_char_comp( jobv );
+    char jobq_ = to_char_compq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;
@@ -226,9 +226,9 @@ int64_t tgsja(
         lapack_error_if( std::abs(ldv) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char jobu_ = job_compu2char( jobu );
-    char jobv_ = job_comp2char( jobv );
-    char jobq_ = job_compq2char( jobq );
+    char jobu_ = to_char_compu( jobu );
+    char jobv_ = to_char_comp( jobv );
+    char jobq_ = to_char_compq( jobq );
     lapack_int m_ = (lapack_int) m;
     lapack_int p_ = (lapack_int) p;
     lapack_int n_ = (lapack_int) n;

--- a/src/tgsyl.cc
+++ b/src/tgsyl.cc
@@ -39,7 +39,7 @@ int64_t tgsyl(
         lapack_error_if( std::abs(lde) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldf) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int ijob_ = (lapack_int) ijob;
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
@@ -116,7 +116,7 @@ int64_t tgsyl(
         lapack_error_if( std::abs(lde) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldf) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int ijob_ = (lapack_int) ijob;
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
@@ -193,7 +193,7 @@ int64_t tgsyl(
         lapack_error_if( std::abs(lde) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldf) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int ijob_ = (lapack_int) ijob;
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
@@ -270,7 +270,7 @@ int64_t tgsyl(
         lapack_error_if( std::abs(lde) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldf) > std::numeric_limits<lapack_int>::max() );
     }
-    char trans_ = op2char( trans );
+    char trans_ = to_char( trans );
     lapack_int ijob_ = (lapack_int) ijob;
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;

--- a/src/tpcon.cc
+++ b/src/tpcon.cc
@@ -25,9 +25,9 @@ int64_t tpcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -57,9 +57,9 @@ int64_t tpcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -89,9 +89,9 @@ int64_t tpcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -121,9 +121,9 @@ int64_t tpcon(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/tpmlqt.cc
+++ b/src/tpmlqt.cc
@@ -42,8 +42,8 @@ int64_t tpmlqt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -98,8 +98,8 @@ int64_t tpmlqt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -150,8 +150,8 @@ int64_t tpmlqt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -317,8 +317,8 @@ int64_t tpmlqt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/tpmqrt.cc
+++ b/src/tpmqrt.cc
@@ -42,8 +42,8 @@ int64_t tpmqrt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -98,8 +98,8 @@ int64_t tpmqrt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -150,8 +150,8 @@ int64_t tpmqrt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -320,8 +320,8 @@ int64_t tpmqrt(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/tprfb.cc
+++ b/src/tprfb.cc
@@ -39,10 +39,10 @@ void tprfb(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -89,10 +89,10 @@ void tprfb(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -139,10 +139,10 @@ void tprfb(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -355,10 +355,10 @@ void tprfb(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
-    char direction_ = direction2char( direction );
-    char storev_ = storev2char( storev );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
+    char direction_ = to_char( direction );
+    char storev_ = to_char( storev );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/tprfs.cc
+++ b/src/tprfs.cc
@@ -31,9 +31,9 @@ int64_t tprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -76,9 +76,9 @@ int64_t tprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -121,9 +121,9 @@ int64_t tprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -166,9 +166,9 @@ int64_t tprfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/tptri.cc
+++ b/src/tptri.cc
@@ -23,8 +23,8 @@ int64_t tptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -47,8 +47,8 @@ int64_t tptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -71,8 +71,8 @@ int64_t tptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -95,8 +95,8 @@ int64_t tptri(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/tptrs.cc
+++ b/src/tptrs.cc
@@ -26,9 +26,9 @@ int64_t tptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -57,9 +57,9 @@ int64_t tptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -88,9 +88,9 @@ int64_t tptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;
@@ -119,9 +119,9 @@ int64_t tptrs(
         lapack_error_if( std::abs(nrhs) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int ldb_ = (lapack_int) ldb;

--- a/src/tpttf.cc
+++ b/src/tpttf.cc
@@ -24,8 +24,8 @@ int64_t tpttf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -50,8 +50,8 @@ int64_t tpttf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -76,8 +76,8 @@ int64_t tpttf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 
@@ -102,8 +102,8 @@ int64_t tpttf(
     if (sizeof(int64_t) > sizeof(lapack_int)) {
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int info_ = 0;
 

--- a/src/tpttr.cc
+++ b/src/tpttr.cc
@@ -25,7 +25,7 @@ int64_t tpttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -52,7 +52,7 @@ int64_t tpttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -79,7 +79,7 @@ int64_t tpttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -106,7 +106,7 @@ int64_t tpttr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/trcon.cc
+++ b/src/trcon.cc
@@ -26,9 +26,9 @@ int64_t trcon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -60,9 +60,9 @@ int64_t trcon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -94,9 +94,9 @@ int64_t trcon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -128,9 +128,9 @@ int64_t trcon(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char norm_ = norm2char( norm );
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char norm_ = to_char( norm );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/trevc.cc
+++ b/src/trevc.cc
@@ -33,8 +33,8 @@ int64_t trevc(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -86,8 +86,8 @@ int64_t trevc(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -139,8 +139,8 @@ int64_t trevc(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -314,8 +314,8 @@ int64_t trevc(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );

--- a/src/trevc3.cc
+++ b/src/trevc3.cc
@@ -36,8 +36,8 @@ int64_t trevc3(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -105,8 +105,8 @@ int64_t trevc3(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -174,8 +174,8 @@ int64_t trevc3(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -370,8 +370,8 @@ int64_t trevc3(
         lapack_error_if( std::abs(ldvr) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(mm) > std::numeric_limits<lapack_int>::max() );
     }
-    char sides_ = sides2char( sides );
-    char howmany_ = howmany2char( howmany );
+    char sides_ = to_char( sides );
+    char howmany_ = to_char( howmany );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );

--- a/src/trexc.cc
+++ b/src/trexc.cc
@@ -29,7 +29,7 @@ int64_t trexc(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
+    char compq_ = to_char_comp( compq );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int ldq_ = (lapack_int) ldq;
@@ -68,7 +68,7 @@ int64_t trexc(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
+    char compq_ = to_char_comp( compq );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int ldq_ = (lapack_int) ldq;
@@ -107,7 +107,7 @@ int64_t trexc(
         lapack_error_if( std::abs(ifst) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ilst) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
+    char compq_ = to_char_comp( compq );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int ldq_ = (lapack_int) ldq;
@@ -140,7 +140,7 @@ int64_t trexc(
         lapack_error_if( std::abs(ifst) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ilst) > std::numeric_limits<lapack_int>::max() );
     }
-    char compq_ = job_comp2char( compq );
+    char compq_ = to_char_comp( compq );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int ldq_ = (lapack_int) ldq;

--- a/src/trrfs.cc
+++ b/src/trrfs.cc
@@ -32,9 +32,9 @@ int64_t trrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -79,9 +79,9 @@ int64_t trrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -126,9 +126,9 @@ int64_t trrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -173,9 +173,9 @@ int64_t trrfs(
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldx) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/trsen.cc
+++ b/src/trsen.cc
@@ -32,8 +32,8 @@ int64_t trsen(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char sense_ = sense2char( sense );
-    char compq_ = job_comp2char( compq );
+    char sense_ = to_char( sense );
+    char compq_ = to_char_comp( compq );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -113,8 +113,8 @@ int64_t trsen(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char sense_ = sense2char( sense );
-    char compq_ = job_comp2char( compq );
+    char sense_ = to_char( sense );
+    char compq_ = to_char_comp( compq );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -194,8 +194,8 @@ int64_t trsen(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char sense_ = sense2char( sense );
-    char compq_ = job_comp2char( compq );
+    char sense_ = to_char( sense );
+    char compq_ = to_char_comp( compq );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );
@@ -258,8 +258,8 @@ int64_t trsen(
         lapack_error_if( std::abs(ldt) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char sense_ = sense2char( sense );
-    char compq_ = job_comp2char( compq );
+    char sense_ = to_char( sense );
+    char compq_ = to_char_comp( compq );
 
     // lapack_logical (32 or 64-bit) copy
     std::vector< lapack_logical > select_( &select[0], &select[(n)] );

--- a/src/trtri.cc
+++ b/src/trtri.cc
@@ -24,8 +24,8 @@ int64_t trtri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -50,8 +50,8 @@ int64_t trtri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -76,8 +76,8 @@ int64_t trtri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -102,8 +102,8 @@ int64_t trtri(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/trtrs.cc
+++ b/src/trtrs.cc
@@ -27,9 +27,9 @@ int64_t trtrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -60,9 +60,9 @@ int64_t trtrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -93,9 +93,9 @@ int64_t trtrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;
@@ -126,9 +126,9 @@ int64_t trtrs(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldb) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
-    char diag_ = diag2char( diag );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
+    char diag_ = to_char( diag );
     lapack_int n_ = (lapack_int) n;
     lapack_int nrhs_ = (lapack_int) nrhs;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/trttf.cc
+++ b/src/trttf.cc
@@ -25,8 +25,8 @@ int64_t trttf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -53,8 +53,8 @@ int64_t trttf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -81,8 +81,8 @@ int64_t trttf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -109,8 +109,8 @@ int64_t trttf(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char transr_ = op2char( transr );
-    char uplo_ = uplo2char( uplo );
+    char transr_ = to_char( transr );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/trttp.cc
+++ b/src/trttp.cc
@@ -25,7 +25,7 @@ int64_t trttp(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -52,7 +52,7 @@ int64_t trttp(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -79,7 +79,7 @@ int64_t trttp(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -106,7 +106,7 @@ int64_t trttp(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/ungbr.cc
+++ b/src/ungbr.cc
@@ -29,7 +29,7 @@ int64_t ungbr(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -143,7 +143,7 @@ int64_t ungbr(
         lapack_error_if( std::abs(k) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
+    char vect_ = to_char( vect );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/ungtr.cc
+++ b/src/ungtr.cc
@@ -27,7 +27,7 @@ int64_t ungtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;
@@ -109,7 +109,7 @@ int64_t ungtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
     lapack_int info_ = 0;

--- a/src/unhr_col.cc
+++ b/src/unhr_col.cc
@@ -40,6 +40,9 @@ int64_t unhr_col(
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int info_ = 0;
 
+    // Work around bug in LAPACK <= 3.12. See https://github.com/Reference-LAPACK/lapack/pull/1018
+    nb_ = min( nb_, n );
+
     LAPACK_cunhr_col(
         &m_, &n_, &nb_,
         (lapack_complex_float*) A, &lda_,
@@ -158,6 +161,9 @@ int64_t unhr_col(
     lapack_int lda_ = (lapack_int) lda;
     lapack_int ldt_ = (lapack_int) ldt;
     lapack_int info_ = 0;
+
+    // Work around bug in LAPACK <= 3.12. See https://github.com/Reference-LAPACK/lapack/pull/1018
+    nb_ = min( nb_, n );
 
     LAPACK_zunhr_col(
         &m_, &n_, &nb_,

--- a/src/unmbr.cc
+++ b/src/unmbr.cc
@@ -31,9 +31,9 @@ int64_t unmbr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char vect_ = to_char( vect );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -180,9 +180,9 @@ int64_t unmbr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char vect_ = vect2char( vect );
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char vect_ = to_char( vect );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/unmhr.cc
+++ b/src/unmhr.cc
@@ -32,8 +32,8 @@ int64_t unmhr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;
@@ -161,8 +161,8 @@ int64_t unmhr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ilo_ = (lapack_int) ilo;

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -31,8 +31,8 @@ int64_t unmlq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -153,8 +153,8 @@ int64_t unmlq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/unmql.cc
+++ b/src/unmql.cc
@@ -31,8 +31,8 @@ int64_t unmql(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -154,8 +154,8 @@ int64_t unmql(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -31,8 +31,8 @@ int64_t unmqr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -155,8 +155,8 @@ int64_t unmqr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/unmrq.cc
+++ b/src/unmrq.cc
@@ -31,8 +31,8 @@ int64_t unmrq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -153,8 +153,8 @@ int64_t unmrq(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/unmrz.cc
+++ b/src/unmrz.cc
@@ -31,8 +31,8 @@ int64_t unmrz(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;
@@ -88,8 +88,8 @@ int64_t unmrz(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int k_ = (lapack_int) k;

--- a/src/unmtr.cc
+++ b/src/unmtr.cc
@@ -30,9 +30,9 @@ int64_t unmtr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;
@@ -151,9 +151,9 @@ int64_t unmtr(
         lapack_error_if( std::abs(lda) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int lda_ = (lapack_int) lda;

--- a/src/upgtr.cc
+++ b/src/upgtr.cc
@@ -27,7 +27,7 @@ int64_t upgtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldq_ = (lapack_int) ldq;
     lapack_int info_ = 0;
@@ -60,7 +60,7 @@ int64_t upgtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldq) > std::numeric_limits<lapack_int>::max() );
     }
-    char uplo_ = uplo2char( uplo );
+    char uplo_ = to_char( uplo );
     lapack_int n_ = (lapack_int) n;
     lapack_int ldq_ = (lapack_int) ldq;
     lapack_int info_ = 0;

--- a/src/upmtr.cc
+++ b/src/upmtr.cc
@@ -29,9 +29,9 @@ int64_t upmtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;
@@ -133,9 +133,9 @@ int64_t upmtr(
         lapack_error_if( std::abs(n) > std::numeric_limits<lapack_int>::max() );
         lapack_error_if( std::abs(ldc) > std::numeric_limits<lapack_int>::max() );
     }
-    char side_ = side2char( side );
-    char uplo_ = uplo2char( uplo );
-    char trans_ = op2char( trans );
+    char side_ = to_char( side );
+    char uplo_ = to_char( uplo );
+    char trans_ = to_char( trans );
     lapack_int m_ = (lapack_int) m;
     lapack_int n_ = (lapack_int) n;
     lapack_int ldc_ = (lapack_int) ldc;

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,0 +1,69 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "lapack/util.hh"
+
+namespace lapack {
+
+const char* Sides_help          = "eigvec: L=Left, R=Right, "
+                                  "B=Both left and right";
+
+const char* Norm_help           = "1=O=One norm, I=Inf norm, 2=Two norm, "
+                                  "F=Fro Frobenius norm, M=Max norm";
+
+const char* itype_help          = "generalized eigenvalue problem type: "
+                                  "1, 2, or 3. "
+                                  "Type 1: Ax = lBx, "
+                                  "type 2: ABx = lx, "
+                                  "type 3: BAx = lx";
+
+#define Job_eig                   "N=NoVec, V=Vectors"
+const char* Job_eig_help        = "eigvec: "       Job_eig;
+const char* Job_eig_left_help   = "left eigvec: "  Job_eig;
+const char* Job_eig_right_help  = "right eigvec: " Job_eig;
+
+#define Job_svd                   "singular vectors: A=All, " \
+                                  "S=Some ('economy size'), " \
+                                  "O=Overwrite A, N=NoVec"
+const char* Job_svd_left_help   = "left "  Job_svd;
+const char* Job_svd_right_help  = "right " Job_svd;
+
+const char* JobSchur_help       = "E=Eigval, S=Schur form";
+
+const char* Sort_help           = "N=NotSorted, S=Sorted";
+
+const char* Range_help          = "eig/svd value range: A=All, V=Value, I=Index";
+
+const char* Vect_help           = "form Q or P: Q, P, N=None, B=Both";
+
+const char* Direction_help      = "apply Householder H: F=Forward H = H1...Hk, "
+                                  "B=Backward H = Hk...H1";
+
+const char* StoreV_help         = "Householder vectors stored: "
+                                  "R=Row=Rowwise, C=Col=Colwise";
+
+const char* MatrixType_help     = "G=General, L=Lower, U=Upper, H=Hessenberg, "
+                                  "B=Band-lower, Q=Band-upper, Z=Band";
+
+const char* HowMany_help        = "A=All, B=Backtransform all, S=Select";
+
+const char* Equed_help          = "Equilibrate: N=None, R=Row, C=Col, B=Both, "
+                                  "Y=Yes";
+
+const char* Factored_help       = "F=Factored, N=NotFactored, E=Equilibrate";
+
+const char* Sense_help          = "N=None, E=Eigval, V=Subspace, B=Both";
+
+const char* JobCond_help        = "E=Eigvec (Hermitian), L=Left singular vectors, "
+                                  "R=Right singular vectors";
+
+const char* Balance_help        = "N=None, P=Permute, S=Scale, B=Both";
+
+const char* Order_help          = "order eigvals within: "
+                                  "B=Block, E=Entire matrix";
+
+const char* RowCol_help         = "check orthogonality of: R=Row, C=Col";
+
+}  // namespace lapack

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ if (NOT TARGET testsweeper)
         message( "   Found TestSweeper library: ${testsweeper_DIR}" )
     else()
         set( url "https://github.com/icl-utk-edu/testsweeper" )
-        set( tag "v2023.11.05" )
+        set( tag "46266dbd5b9560413a379d5c17764aadf96e1890" ) # 2024-05-24
         message( "" )
         message( "---------- TestSweeper" )
         message( STATUS "Fetching TestSweeper ${tag} from ${url}" )

--- a/test/blas_wrappers.hh
+++ b/test/blas_wrappers.hh
@@ -66,7 +66,7 @@ inline void hbmv(
     float beta,
     float       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int kd_   = kd;
     blas_int ldab_ = ldab;
@@ -86,7 +86,7 @@ inline void hbmv(
     double beta,
     double       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int kd_   = kd;
     blas_int ldab_ = ldab;
@@ -106,7 +106,7 @@ inline void hbmv(
     std::complex<float> beta,
     std::complex<float>       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int kd_   = kd;
     blas_int ldab_ = ldab;
@@ -130,7 +130,7 @@ inline void hbmv(
     std::complex<double> beta,
     std::complex<double>       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int kd_   = kd;
     blas_int ldab_ = ldab;
@@ -224,7 +224,7 @@ inline void hpmv(
     float beta,
     float       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int incb_ = incb;
     blas_int incc_ = incc;
@@ -242,7 +242,7 @@ inline void hpmv(
     double beta,
     double       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int incb_ = incb;
     blas_int incc_ = incc;
@@ -260,7 +260,7 @@ inline void hpmv(
     std::complex<float> beta,
     std::complex<float>       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int incb_ = incb;
     blas_int incc_ = incc;
@@ -282,7 +282,7 @@ inline void hpmv(
     std::complex<double> beta,
     std::complex<double>       *C, int64_t incc )
 {
-    char uplo_     = uplo2char( uplo );
+    char uplo_     = to_char( uplo );
     blas_int n_    = n;
     blas_int incb_ = incb;
     blas_int incc_ = incc;

--- a/test/check_geev.hh
+++ b/test/check_geev.hh
@@ -247,7 +247,7 @@ void check_geev(
 
     if (verbose >= 1) {
         printf( "error: { ||A^{%c} V - V W||=%.2e / (||V||=%.2e ||A||=%.2e) } = %.2e;  n=%.0f\n",
-                op2char(trans), error, Vnorm, Anorm, results[0], real_t(n) );
+                to_char( trans ), error, Vnorm, Anorm, results[0], real_t( n ) );
     }
 
     results[1] = check_geev_Vnormalization( n, W, V, ldv );

--- a/test/lapacke_wrappers.hh
+++ b/test/lapacke_wrappers.hh
@@ -10008,8 +10008,8 @@ inline lapack_int LAPACKE_ungtr(
 }
 
 // -----------------------------------------------------------------------------
-// LAPACKE_*unhr_col only in Intel MKL, not yet Netlib LAPACK as of 3.10.
-#if LAPACK_VERSION >= 30900 && defined( LAPACK_HAVE_MKL ) // >= 3.9.0
+// LAPACKE_*unhr_col only in Intel MKL until LAPACK 3.12.
+#if LAPACK_VERSION >= 31200 || (LAPACK_VERSION >= 30900 && defined( LAPACK_HAVE_MKL ))
 
 inline lapack_int LAPACKE_orhr_col(
     lapack_int m, lapack_int n, lapack_int nb,
@@ -10083,7 +10083,7 @@ inline lapack_int LAPACKE_unhr_col(
         (lapack_complex_double*) D );
 }
 
-#endif  // 3.9.0 and LAPACK_HAVE_MKL
+#endif  // 3.12.0 or (3.9.0 and LAPACK_HAVE_MKL)
 
 
 // -----------------------------------------------------------------------------

--- a/test/test.hh
+++ b/test/test.hh
@@ -11,17 +11,14 @@
 #include "matrix_params.hh"
 #include "matrix_generator.hh"
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 using llong = long long;
 
-// -----------------------------------------------------------------------------
-class Params: public testsweeper::ParamsBase
-{
+//------------------------------------------------------------------------------
+class Params: public testsweeper::ParamsBase {
 public:
     const double inf = std::numeric_limits<double>::infinity();
     const double nan = std::numeric_limits<double>::quiet_NaN();
-    const double pi  = 3.141592653589793;
-    const double e   = 2.718281828459045;
 
     Params();
 
@@ -37,12 +34,7 @@ public:
 
     // Field members are explicitly public.
     // Order here determines output order.
-
-    // ----- test matrix parameters
-    MatrixParams matrix;
-    MatrixParams matrixB;
-
-    // ----- test framework parameters
+    //----- test framework parameters
     testsweeper::ParamChar   check;
     testsweeper::ParamChar   error_exit;
     testsweeper::ParamChar   ref;
@@ -51,56 +43,73 @@ public:
     testsweeper::ParamInt    verbose;
     testsweeper::ParamInt    cache;
 
-    // ----- routine parameters
+    //----- test matrix parameters
+    MatrixParams matrix;
+    MatrixParams matrixB;
+
+    //----- routine parameters, enums
     testsweeper::ParamEnum< testsweeper::DataType > datatype;
-    testsweeper::ParamEnum< blas::Layout >      layout;
-    testsweeper::ParamEnum< lapack::Side >      side;
-    testsweeper::ParamInt                       itype;
-    testsweeper::ParamEnum< lapack::Uplo >      uplo;
-    testsweeper::ParamEnum< lapack::Op >        trans;
-    testsweeper::ParamEnum< lapack::Op >        transA;
-    testsweeper::ParamEnum< lapack::Op >        transB;
-    testsweeper::ParamEnum< lapack::Diag >      diag;
-    testsweeper::ParamEnum< lapack::Norm >      norm;
-    testsweeper::ParamEnum< lapack::Direction > direction;
-    testsweeper::ParamEnum< lapack::StoreV >    storev;
-    testsweeper::ParamInt                       ijob;   // tgsen
-    testsweeper::ParamEnum< lapack::Job >       jobz;   // heev
-    testsweeper::ParamEnum< lapack::Job >       jobvl;  // geev
-    testsweeper::ParamEnum< lapack::Job >       jobvr;  // geev
-    testsweeper::ParamEnum< lapack::Job >       jobu;   // gesvd, gesdd
-    testsweeper::ParamEnum< lapack::Job >       jobvt;  // gesvd
-    testsweeper::ParamEnum< lapack::Range >     range;
-    testsweeper::ParamEnum< lapack::MatrixType > matrixtype;
-    testsweeper::ParamEnum< lapack::Factored >  factored;
-    testsweeper::ParamEnum< lapack::Equed >     equed;
 
-    testsweeper::ParamInt3   dim;
-    testsweeper::ParamInt    i;
-    testsweeper::ParamInt    l;
-    testsweeper::ParamInt    ka;
-    testsweeper::ParamInt    kb;
-    testsweeper::ParamInt    kd;
-    testsweeper::ParamInt    kl;
-    testsweeper::ParamInt    ku;
-    testsweeper::ParamInt    nrhs;
-    testsweeper::ParamInt    nb;
-    testsweeper::ParamDouble vl;
-    testsweeper::ParamDouble vu;
-    testsweeper::ParamInt    il;
-    testsweeper::ParamInt    il_out;
-    testsweeper::ParamInt    iu;
-    testsweeper::ParamInt    iu_out;
-    testsweeper::ParamDouble fraction_start;
-    testsweeper::ParamDouble fraction;
-    testsweeper::ParamDouble alpha;
-    testsweeper::ParamDouble beta;
-    testsweeper::ParamInt    incx;
-    testsweeper::ParamInt    incy;
-    testsweeper::ParamInt    align;
-    testsweeper::ParamInt    device;
+    // BLAS & LAPACK options
+    // The order here matches the order in most LAPACK functions, e.g.,
+    // hegv ( itype, jobz, uplo, n, ... )
+    // syevx( jobz, range, uplo, n, ..., vl, vu, il, iu, ... )
+    // larfb( side, trans, direction, storev, m, n, k, ... )
+    // lanhe( norm, uplo, n, ... )
+    // pbsv ( uplo, n, kd, nrhs, ... )
+    // gbsv ( n, kl, ku, nrhs, ... )
+    // trsm ( side, uplo, transa, diag, m, n, alpha, ... )
+    // gesvx( fact, trans, n, nrhs, ..., equed, ... )
+    // ijob, itype are classified as enums due to their limited values.
+    testsweeper::ParamEnum< blas::Layout >          layout;
+    testsweeper::ParamInt                           ijob;   // tgsen
+    testsweeper::ParamInt                           itype;  // hegv
+    testsweeper::ParamEnum< lapack::Job >           jobz;   // heev
+    testsweeper::ParamEnum< lapack::Job >           jobvl;  // geev
+    testsweeper::ParamEnum< lapack::Job >           jobvr;  // geev
+    testsweeper::ParamEnum< lapack::Job >           jobu;   // svd
+    testsweeper::ParamEnum< lapack::Job >           jobvt;  // svd
+    testsweeper::ParamEnum< lapack::Range >         range;  // heevx
+    testsweeper::ParamEnum< lapack::Norm >          norm;
+    testsweeper::ParamEnum< lapack::MatrixType >    matrixtype; // lascl
+    testsweeper::ParamEnum< lapack::Factored >      factored;   // gesvx
+    testsweeper::ParamEnum< blas::Side >            side;
+    testsweeper::ParamEnum< blas::Uplo >            uplo;
+    testsweeper::ParamEnum< blas::Op >              trans;
+    testsweeper::ParamEnum< blas::Op >              transA;
+    testsweeper::ParamEnum< blas::Op >              transB;
+    testsweeper::ParamEnum< blas::Diag >            diag;
+    testsweeper::ParamEnum< lapack::Direction >     direction;  // larfb
+    testsweeper::ParamEnum< lapack::StoreV >        storev;     // larfb
+    testsweeper::ParamEnum< lapack::Equed >         equed;      // gesvx
 
-    // ----- output parameters
+    //----- routine parameters, numeric
+    testsweeper::ParamInt3    dim;  // m, n, k
+    testsweeper::ParamInt     i;
+    testsweeper::ParamInt     l;
+    testsweeper::ParamInt     ka;
+    testsweeper::ParamInt     kb;
+    testsweeper::ParamInt     kd;
+    testsweeper::ParamInt     kl;
+    testsweeper::ParamInt     ku;
+    testsweeper::ParamInt     nrhs;
+    testsweeper::ParamInt     nb;
+    testsweeper::ParamDouble  vl;
+    testsweeper::ParamDouble  vu;
+    testsweeper::ParamInt     il;
+    testsweeper::ParamInt     iu;
+    testsweeper::ParamInt     il_out;
+    testsweeper::ParamInt     iu_out;
+    testsweeper::ParamDouble  fraction_start;
+    testsweeper::ParamDouble  fraction;
+    testsweeper::ParamComplex alpha;
+    testsweeper::ParamComplex beta;
+    testsweeper::ParamInt     incx;
+    testsweeper::ParamInt     incy;
+    testsweeper::ParamInt     align;
+    testsweeper::ParamInt     device;
+
+    //----- output parameters
     testsweeper::ParamScientific error;
     testsweeper::ParamScientific error2;
     testsweeper::ParamScientific error3;
@@ -115,18 +124,6 @@ public:
     testsweeper::ParamDouble     gbytes;
     testsweeper::ParamInt        iters;
 
-    testsweeper::ParamDouble     time2;
-    testsweeper::ParamDouble     gflops2;
-    testsweeper::ParamDouble     gbytes2;
-
-    testsweeper::ParamDouble     time3;
-    testsweeper::ParamDouble     gflops3;
-    testsweeper::ParamDouble     gbytes3;
-
-    testsweeper::ParamDouble     time4;
-    testsweeper::ParamDouble     gflops4;
-    testsweeper::ParamDouble     gbytes4;
-
     testsweeper::ParamDouble     ref_time;
     testsweeper::ParamDouble     ref_gflops;
     testsweeper::ParamDouble     ref_gbytes;
@@ -136,14 +133,14 @@ public:
     testsweeper::ParamString     msg;
 };
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 template< typename T >
 inline T roundup( T x, T y )
 {
     return T( (x + y - 1) / y ) * y;
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 #ifndef assert_throw
     #define assert_throw( expr, exception_type ) \
         try { \
@@ -159,7 +156,7 @@ inline T roundup( T x, T y )
         }
 #endif
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // Like assert(), but throws error and is not disabled by NDEBUG.
 inline
 void require_( bool cond, const char* condstr, const char* file, int line )
@@ -172,7 +169,7 @@ void require_( bool cond, const char* condstr, const char* file, int line )
 
 #define require( cond ) require_( (cond), #cond, __FILE__, __LINE__ )
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // LAPACK
 // LU, general
 void test_gesv  ( Params& params, bool run );

--- a/test/test_gbcon.cc
+++ b/test/test_gbcon.cc
@@ -76,7 +76,7 @@ void test_gbcon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gbcon( norm2char(norm), n, kl, ku, &AB[0], ldab, &ipiv_ref[0], anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_gbcon( to_char( norm ), n, kl, ku, &AB[0], ldab, &ipiv_ref[0], anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gbcon returned error %lld\n", llong( info_ref ) );

--- a/test/test_gbrfs.cc
+++ b/test/test_gbrfs.cc
@@ -164,7 +164,7 @@ void test_gbrfs_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_gbrfs(
-            op2char(trans), n, kl, ku, nrhs,
+            to_char( trans ), n, kl, ku, nrhs,
             &AB[ kl ], ldab, &AFB[0], ldafb, &ipiv_ref[0],
             &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;

--- a/test/test_gbtrs.cc
+++ b/test/test_gbtrs.cc
@@ -128,7 +128,7 @@ void test_gbtrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gbtrs( op2char(trans), n, kl, ku, nrhs, &AB_tst[0], ldab, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_gbtrs( to_char( trans ), n, kl, ku, nrhs, &AB_tst[0], ldab, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gbtrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_gecon.cc
+++ b/test/test_gecon.cc
@@ -62,7 +62,7 @@ void test_gecon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gecon( norm2char(norm), n, &A[0], lda, anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_gecon( to_char( norm ), n, &A[0], lda, anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gecon returned error %lld\n", llong( info_ref ) );

--- a/test/test_geev.cc
+++ b/test/test_geev.cc
@@ -153,7 +153,7 @@ void test_geev_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
     //printf (" ref start\n");
-        int64_t info_ref = LAPACKE_geev( job2char(jobvl), job2char(jobvr), n, &A_ref[0], lda, &W_ref[0], &VL_ref[0], ldvl, &VR_ref[0], ldvr );
+        int64_t info_ref = LAPACKE_geev( to_char( jobvl ), to_char( jobvr ), n, &A_ref[0], lda, &W_ref[0], &VL_ref[0], ldvl, &VR_ref[0], ldvr );
     //printf (" ref done\n");
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -87,7 +87,7 @@ void test_gels_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gels( op2char(trans), m, n, nrhs, &A_ref[0], lda, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_gels( to_char( trans ), m, n, nrhs, &A_ref[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gels returned error %lld\n", llong( info_ref ) );

--- a/test/test_gemqrt.cc
+++ b/test/test_gemqrt.cc
@@ -91,7 +91,7 @@ void test_gemqrt_work( Params& params, bool run )
         //---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gemqrt( side2char(side), op2char(trans), m, n, k, nb, &V[0], ldv, &T[0], ldt, &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_gemqrt( to_char( side ), to_char( trans ), m, n, k, nb, &V[0], ldv, &T[0], ldt, &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gemqrt returned error %lld\n", llong( info_ref ) );

--- a/test/test_gerfs.cc
+++ b/test/test_gerfs.cc
@@ -97,7 +97,7 @@ void test_gerfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gerfs( op2char(trans), n, nrhs, &A[0], lda, &AF[0], lda, &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_gerfs( to_char( trans ), n, nrhs, &A[0], lda, &AF[0], lda, &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gerfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_gesdd.cc
+++ b/test/test_gesdd.cc
@@ -110,7 +110,7 @@ void test_gesdd_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gesdd( job2char(jobu), m, n, &A_ref[0], lda, &S_ref[0], &U_ref[0], ldu, &VT_ref[0], ldvt );
+        int64_t info_ref = LAPACKE_gesdd( to_char( jobu ), m, n, &A_ref[0], lda, &S_ref[0], &U_ref[0], ldu, &VT_ref[0], ldvt );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gesdd returned error %lld\n", llong( info_ref ) );

--- a/test/test_gesvd.cc
+++ b/test/test_gesvd.cc
@@ -138,7 +138,7 @@ void test_gesvd_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gesvd( job2char(jobu), job2char(jobvt), m, n, &A_ref[0], lda, &S_ref[0], &U_ref[0], ldu, &VT_ref[0], ldvt );
+        int64_t info_ref = LAPACKE_gesvd( to_char( jobu ), to_char( jobvt ), m, n, &A_ref[0], lda, &S_ref[0], &U_ref[0], ldu, &VT_ref[0], ldvt );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gesvd returned error %lld\n", llong( info_ref ) );

--- a/test/test_gesvdx.cc
+++ b/test/test_gesvdx.cc
@@ -91,7 +91,7 @@ void test_gesvdx_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gesvdx( job2char(jobu), job2char(jobvt), range2char(range), m, n, &A_ref[0], lda, vl, vu, il, iu, &ns_ref, &S_ref[0], &U_ref[0], ldu, &VT_ref[0], ldvt );
+        int64_t info_ref = LAPACKE_gesvdx( to_char( jobu ), to_char( jobvt ), to_char( range ), m, n, &A_ref[0], lda, vl, vu, il, iu, &ns_ref, &S_ref[0], &U_ref[0], ldu, &VT_ref[0], ldvt );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gesvdx returned error %lld\n", llong( info_ref ) );

--- a/test/test_gesvx.cc
+++ b/test/test_gesvx.cc
@@ -148,17 +148,16 @@ void test_gesvx_work( Params& params, bool run )
     if (params.ref() == 'y') {
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
-        char equed_ref_char = lapack::equed2char( equed_ref );
+        char equed_ref_char = to_char( equed_ref );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_gesvx(
-                               factored2char(fact), op2char(trans), n, nrhs,
+                               to_char( fact ), to_char( trans ), n, nrhs,
                                &A_ref[0], lda,
                                &AF_ref[0], ldaf, &ipiv_ref[0],
                                &equed_ref_char, &R_ref[0], &C_ref[0],
                                &B_ref[0], ldb, &X_ref[0], ldx,
                                &rcond_ref, &ferr_ref[0], &berr_ref[0], &rpivot_ref );
         time = testsweeper::get_wtime() - time;
-        equed_ref = lapack::char2equed( equed_ref_char );
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gesvx returned error %lld\n", llong( info_ref ) );
         }

--- a/test/test_getrs.cc
+++ b/test/test_getrs.cc
@@ -100,7 +100,7 @@ void test_getrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_getrs( op2char(trans), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_getrs( to_char( trans ), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_getrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_getsls.cc
+++ b/test/test_getsls.cc
@@ -90,7 +90,7 @@ void test_getsls_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_getsls( op2char(trans), m, n, nrhs, &A_ref[0], lda, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_getsls( to_char( trans ), m, n, nrhs, &A_ref[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_getsls returned error %lld\n", llong( info_ref ) );

--- a/test/test_ggev.cc
+++ b/test/test_ggev.cc
@@ -84,7 +84,7 @@ void test_ggev_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_ggev( job2char(jobvl), job2char(jobvr), n, &A_ref[0], lda, &B_ref[0], ldb, &alpha_ref[0], &beta_ref[0], &VL_ref[0], ldvl, &VR_ref[0], ldvr );
+        int64_t info_ref = LAPACKE_ggev( to_char( jobvl ), to_char( jobvr ), n, &A_ref[0], lda, &B_ref[0], ldb, &alpha_ref[0], &beta_ref[0], &VL_ref[0], ldvl, &VR_ref[0], ldvr );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_ggev returned error %lld\n", llong( info_ref ) );

--- a/test/test_gtcon.cc
+++ b/test/test_gtcon.cc
@@ -83,7 +83,7 @@ void test_gtcon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gtcon( norm2char(norm), n, &DL[0], &D[0], &DU[0], &DU2[0], &ipiv_ref[0], anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_gtcon( to_char( norm ), n, &DL[0], &D[0], &DU[0], &DU2[0], &ipiv_ref[0], anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gtcon returned error %lld\n", llong( info_ref ) );

--- a/test/test_gtrfs.cc
+++ b/test/test_gtrfs.cc
@@ -114,7 +114,7 @@ void test_gtrfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gtrfs( op2char(trans), n, nrhs, &DL[0], &D[0], &DU[0], &DLF[0], &DF[0], &DUF[0], &DU2[0], &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_gtrfs( to_char( trans ), n, nrhs, &DL[0], &D[0], &DU[0], &DLF[0], &DF[0], &DUF[0], &DU2[0], &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gtrfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_gttrs.cc
+++ b/test/test_gttrs.cc
@@ -84,7 +84,7 @@ void test_gttrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_gttrs( op2char(trans), n, nrhs, &DL[0], &D[0], &DU[0], &DU2[0], &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_gttrs( to_char( trans ), n, nrhs, &DL[0], &D[0], &DU[0], &DU2[0], &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_gttrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_hbev.cc
+++ b/test/test_hbev.cc
@@ -129,7 +129,7 @@ void test_hbev_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hbev(
-                               job2char(jobz), uplo2char(uplo), n, kd,
+                               to_char( jobz ), to_char( uplo ), n, kd,
                                &Aband_ref[0], lda,
                                &Lambda_ref[0], &Z[0], ldz );
         time = testsweeper::get_wtime() - time;

--- a/test/test_hbevd.cc
+++ b/test/test_hbevd.cc
@@ -128,7 +128,7 @@ void test_hbevd_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hbevd(
-                               job2char(jobz), uplo2char(uplo), n, kd,
+                               to_char( jobz ), to_char( uplo ), n, kd,
                                &Aband_ref[0], lda,
                                &Lambda_ref[0], &Z[0], ldz );
         time = testsweeper::get_wtime() - time;

--- a/test/test_hbevx.cc
+++ b/test/test_hbevx.cc
@@ -147,7 +147,7 @@ void test_hbevx_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hbevx(
-                               job2char(jobz), range2char(range), uplo2char(uplo),
+                               to_char( jobz ), to_char( range ), to_char( uplo ),
                                n, kd,
                                &Aband_ref[0], lda,
                                &Q[0], ldq,

--- a/test/test_hbgv.cc
+++ b/test/test_hbgv.cc
@@ -166,7 +166,7 @@ void test_hbgv_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hbgv(
-                               job2char(jobz), uplo2char(uplo), n, ka, kb,
+                               to_char( jobz ), to_char( uplo ), n, ka, kb,
                                &Aband_ref[0], lda,
                                &Bband_ref[0], ldb,
                                &Lambda_ref[0], &Z[0], ldz );

--- a/test/test_hbgvd.cc
+++ b/test/test_hbgvd.cc
@@ -168,7 +168,7 @@ void test_hbgvd_work( Params& params, bool run )
         // Note: LAPACKE_hbgvd does workspace query that may be wrong
         // (e.g., in LAPACK <= 3.6.0, MKL 2018), so custom version fixes it.
         int64_t info_ref = LAPACKE_hbgvd_custom(
-                               job2char(jobz), uplo2char(uplo), n, ka, kb,
+                               to_char( jobz ), to_char( uplo ), n, ka, kb,
                                &Aband_ref[0], lda,
                                &Bband_ref[0], ldb,
                                &Lambda_ref[0], &Z[0], ldz );

--- a/test/test_hbgvx.cc
+++ b/test/test_hbgvx.cc
@@ -182,7 +182,7 @@ void test_hbgvx_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hbgvx(
-                               job2char(jobz), range2char(range), uplo2char(uplo),
+                               to_char( jobz ), to_char( range ), to_char( uplo ),
                                n, ka, kb,
                                &Aband_ref[0], lda,
                                &Bband_ref[0], ldb,

--- a/test/test_hecon.cc
+++ b/test/test_hecon.cc
@@ -73,7 +73,7 @@ void test_hecon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hecon( uplo2char(uplo), n, &A[0], lda, &ipiv_ref[0], anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_hecon( to_char( uplo ), n, &A[0], lda, &ipiv_ref[0], anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hecon returned error %lld\n", llong( info_ref ) );

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -117,7 +117,7 @@ void test_heev_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_heev(
-            job2char(jobz), uplo2char(uplo), n,
+            to_char( jobz ), to_char( uplo ), n,
             &A[0], lda, &Lambda_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {

--- a/test/test_heevd.cc
+++ b/test/test_heevd.cc
@@ -116,7 +116,7 @@ void test_heevd_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_heevd(
-            job2char(jobz), uplo2char(uplo), n,
+            to_char( jobz ), to_char( uplo ), n,
             &A[0], lda, &Lambda_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {

--- a/test/test_heevd_device.cc
+++ b/test/test_heevd_device.cc
@@ -161,7 +161,7 @@ void test_heevd_device_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_heev(
-            job2char(jobz), uplo2char(uplo), n,
+            to_char( jobz ), to_char( uplo ), n,
             &A[0], lda, &Lambda_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {

--- a/test/test_heevr.cc
+++ b/test/test_heevr.cc
@@ -147,7 +147,7 @@ void test_heevr_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_heevr(
-                               job2char(jobz), range2char(range), uplo2char(uplo), n,
+                               to_char( jobz ), to_char( range ), to_char( uplo ), n,
                                &A_ref[0], lda,
                                vl, vu, il, iu, abstol, &nfound_ref,
                                &Lambda_ref[0], &Z[0], ldz, &isuppz_ref[0] );

--- a/test/test_heevx.cc
+++ b/test/test_heevx.cc
@@ -144,7 +144,7 @@ void test_heevx_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_heevx(
-                               job2char(jobz), range2char(range), uplo2char(uplo), n,
+                               to_char( jobz ), to_char( range ), to_char( uplo ), n,
                                &A_ref[0], lda,
                                vl, vu, il, iu, abstol, &nfound_ref,
                                &Lambda_ref[0], &Z[0], ldz, &ifail_ref[0] );

--- a/test/test_hegst.cc
+++ b/test/test_hegst.cc
@@ -97,7 +97,7 @@ void test_hegst_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hegst(
-            itype, uplo2char(uplo), n, &A_ref[0], lda, &B[0], ldb );
+            itype, to_char( uplo ), n, &A_ref[0], lda, &B[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hegst returned error %lld\n", llong( info_ref ) );

--- a/test/test_hegv.cc
+++ b/test/test_hegv.cc
@@ -180,7 +180,7 @@ void test_hegv_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hegv(
-                               itype, job2char(jobz), uplo2char(uplo), n,
+                               itype, to_char( jobz ), to_char( uplo ), n,
                                &A[0], lda,
                                &B_ref[0], ldb,
                                &Lambda_ref[0] );

--- a/test/test_hegvd.cc
+++ b/test/test_hegvd.cc
@@ -180,7 +180,7 @@ void test_hegvd_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hegvd(
-                               itype, job2char(jobz), uplo2char(uplo), n,
+                               itype, to_char( jobz ), to_char( uplo ), n,
                                &A[0], lda,
                                &B_ref[0], ldb,
                                &Lambda_ref[0] );

--- a/test/test_hegvx.cc
+++ b/test/test_hegvx.cc
@@ -197,7 +197,7 @@ void test_hegvx_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hegvx(
-                               itype, job2char(jobz), range2char(range), uplo2char(uplo), n,
+                               itype, to_char( jobz ), to_char( range ), to_char( uplo ), n,
                                &A_ref[0], lda,
                                &B_ref[0], ldb,
                                vl, vu, il, iu, abstol, &nfound_ref,

--- a/test/test_herfs.cc
+++ b/test/test_herfs.cc
@@ -99,7 +99,7 @@ void test_herfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_herfs( uplo2char(uplo), n, nrhs, &A[0], lda, &AF[0], ldaf, &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_herfs( to_char( uplo ), n, nrhs, &A[0], lda, &AF[0], ldaf, &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_herfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_hesv.cc
+++ b/test/test_hesv.cc
@@ -71,7 +71,7 @@ void test_hesv_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hesv( uplo2char(uplo), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_hesv( to_char( uplo ), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hesv returned error %lld\n", llong( info_ref ) );

--- a/test/test_hetrd.cc
+++ b/test/test_hetrd.cc
@@ -68,7 +68,7 @@ void test_hetrd_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hetrd( uplo2char(uplo), n, &A_ref[0], lda, &D_ref[0], &E_ref[0], &tau_ref[0] );
+        int64_t info_ref = LAPACKE_hetrd( to_char( uplo ), n, &A_ref[0], lda, &D_ref[0], &E_ref[0], &tau_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hetrd returned error %lld\n", llong( info_ref ) );

--- a/test/test_hetrf.cc
+++ b/test/test_hetrf.cc
@@ -62,7 +62,7 @@ void test_hetrf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hetrf( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_hetrf( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hetrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_hetri.cc
+++ b/test/test_hetri.cc
@@ -72,14 +72,14 @@ void test_hetri_work( Params& params, bool run )
     if (params.ref() == 'y' || params.check() == 'y') {
         testsweeper::flush_cache( params.cache() );
         // ---------- factor reference
-        int64_t info_ref_trf = LAPACKE_hetrf( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        int64_t info_ref_trf = LAPACKE_hetrf( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         if (info_ref_trf != 0) {
             fprintf( stderr, "LAPACKE_hetrf returned error %lld\n", llong( info_ref_trf ) );
         }
 
         // ---------- run reference
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hetri( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_hetri( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hetri returned error %lld\n", llong( info_ref ) );

--- a/test/test_hetrs.cc
+++ b/test/test_hetrs.cc
@@ -76,7 +76,7 @@ void test_hetrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hetrs( uplo2char(uplo), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_hetrs( to_char( uplo ), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hetrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_hpcon.cc
+++ b/test/test_hpcon.cc
@@ -73,7 +73,7 @@ void test_hpcon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hpcon( uplo2char(uplo), n, &AP[0], &ipiv_ref[0], anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_hpcon( to_char( uplo ), n, &AP[0], &ipiv_ref[0], anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hpcon returned error %lld\n", llong( info_ref ) );

--- a/test/test_hpev.cc
+++ b/test/test_hpev.cc
@@ -117,7 +117,7 @@ void test_hpev_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hpev(
-                               job2char(jobz), uplo2char(uplo), n,
+                               to_char( jobz ), to_char( uplo ), n,
                                &Apack_ref[0], &Lambda_ref[0], &Z[0], ldz );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {

--- a/test/test_hpevd.cc
+++ b/test/test_hpevd.cc
@@ -115,7 +115,7 @@ void test_hpevd_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hpevd(
-            job2char(jobz), uplo2char(uplo), n,
+            to_char( jobz ), to_char( uplo ), n,
             &Apack_ref[0], &Lambda_ref[0], &Z[0], ldz );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {

--- a/test/test_hpevx.cc
+++ b/test/test_hpevx.cc
@@ -139,7 +139,7 @@ void test_hpevx_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hpevx(
-                               job2char(jobz), range2char(range), uplo2char(uplo), n,
+                               to_char( jobz ), to_char( range ), to_char( uplo ), n,
                                &Apack_ref[0],
                                vl, vu, il, iu, abstol, &nfound_ref,
                                &Lambda_ref[0], &Z[0], ldz, &ifail_ref[0] );

--- a/test/test_hpgst.cc
+++ b/test/test_hpgst.cc
@@ -85,7 +85,7 @@ void test_hpgst_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hpgst( itype, uplo2char(uplo), n, &AP_ref[0], &BP[0] );
+        int64_t info_ref = LAPACKE_hpgst( itype, to_char( uplo ), n, &AP_ref[0], &BP[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hpgst returned error %lld\n", llong( info_ref ) );

--- a/test/test_hpgv.cc
+++ b/test/test_hpgv.cc
@@ -179,7 +179,7 @@ void test_hpgv_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hpgv(
-                               itype, job2char(jobz), uplo2char(uplo), n,
+                               itype, to_char( jobz ), to_char( uplo ), n,
                                &Apack_ref[0],
                                &Bpack_ref[0],
                                &Lambda_ref[0], &Z[0], ldz );

--- a/test/test_hpgvd.cc
+++ b/test/test_hpgvd.cc
@@ -179,7 +179,7 @@ void test_hpgvd_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hpgvd(
-                               itype, job2char(jobz), uplo2char(uplo), n,
+                               itype, to_char( jobz ), to_char( uplo ), n,
                                &Apack_ref[0],
                                &Bpack_ref[0],
                                &Lambda_ref[0], &Z[0], ldz );

--- a/test/test_hpgvx.cc
+++ b/test/test_hpgvx.cc
@@ -193,7 +193,7 @@ void test_hpgvx_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_hpgvx(
-                               itype, job2char(jobz), range2char(range), uplo2char(uplo), n,
+                               itype, to_char( jobz ), to_char( range ), to_char( uplo ), n,
                                &Apack_ref[0],
                                &Bpack_ref[0],
                                vl, vu, il, iu, abstol, &nfound_ref,

--- a/test/test_hprfs.cc
+++ b/test/test_hprfs.cc
@@ -95,7 +95,7 @@ void test_hprfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hprfs( uplo2char(uplo), n, nrhs, &AP[0], &AFP[0], &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_hprfs( to_char( uplo ), n, nrhs, &AP[0], &AFP[0], &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hprfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_hpsv.cc
+++ b/test/test_hpsv.cc
@@ -73,7 +73,7 @@ void test_hpsv_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hpsv( uplo2char(uplo), n, nrhs, &AP_ref[0], &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_hpsv( to_char( uplo ), n, nrhs, &AP_ref[0], &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hpsv returned error %lld\n", llong( info_ref ) );

--- a/test/test_hptrd.cc
+++ b/test/test_hptrd.cc
@@ -67,7 +67,7 @@ void test_hptrd_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hptrd( uplo2char(uplo), n, &AP_ref[0], &D_ref[0], &E_ref[0], &tau_ref[0] );
+        int64_t info_ref = LAPACKE_hptrd( to_char( uplo ), n, &AP_ref[0], &D_ref[0], &E_ref[0], &tau_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hptrd returned error %lld\n", llong( info_ref ) );

--- a/test/test_hptrf.cc
+++ b/test/test_hptrf.cc
@@ -62,7 +62,7 @@ void test_hptrf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hptrf( uplo2char(uplo), n, &AP_ref[0], &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_hptrf( to_char( uplo ), n, &AP_ref[0], &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hptrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_hptri.cc
+++ b/test/test_hptri.cc
@@ -73,7 +73,7 @@ void test_hptri_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hptri( uplo2char(uplo), n, &AP_ref[0], &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_hptri( to_char( uplo ), n, &AP_ref[0], &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hptri returned error %lld\n", llong( info_ref ) );

--- a/test/test_hptrs.cc
+++ b/test/test_hptrs.cc
@@ -75,7 +75,7 @@ void test_hptrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_hptrs( uplo2char(uplo), n, nrhs, &AP[0], &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_hptrs( to_char( uplo ), n, nrhs, &AP[0], &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_hptrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_lacpy.cc
+++ b/test/test_lacpy.cc
@@ -61,7 +61,7 @@ void test_lacpy_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_lacpy( matrixtype2char(matrixtype), m, n, &A[0], lda, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_lacpy( to_char( matrixtype ), m, n, &A[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_lacpy returned error %lld\n", llong( info_ref ) );

--- a/test/test_laed4.cc
+++ b/test/test_laed4.cc
@@ -20,7 +20,7 @@ void test_laed4_work( Params& params, bool run )
     // get & mark input values
     int64_t n = params.dim.n();
     int64_t i = params.i();
-    scalar_t rho = std::abs( params.alpha() );
+    real_t rho = std::abs( params.alpha.get<real_t>() );
 
     assert( 0 <= i && i < n );  // 0-based
 

--- a/test/test_langb.cc
+++ b/test/test_langb.cc
@@ -62,7 +62,7 @@ void test_langb_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_langb( norm2char(norm), n, kl, ku, &AB[0], ldab );
+        real_t norm_ref = LAPACKE_langb( to_char( norm ), n, kl, ku, &AB[0], ldab );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lange.cc
+++ b/test/test_lange.cc
@@ -69,7 +69,7 @@ void test_lange_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lange( norm2char(norm), m, n, &A[0], lda );
+        real_t norm_ref = LAPACKE_lange( to_char( norm ), m, n, &A[0], lda );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_langt.cc
+++ b/test/test_langt.cc
@@ -64,7 +64,7 @@ void test_langt_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_langt( norm2char(norm), n, &DL[0], &D[0], &DU[0] );
+        real_t norm_ref = LAPACKE_langt( to_char( norm ), n, &DL[0], &D[0], &DU[0] );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lanhb.cc
+++ b/test/test_lanhb.cc
@@ -66,7 +66,7 @@ void test_lanhb_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lanhb( norm2char(norm), uplo2char(uplo), n, kd, &AB[0], ldab );
+        real_t norm_ref = LAPACKE_lanhb( to_char( norm ), to_char( uplo ), n, kd, &AB[0], ldab );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lanhe.cc
+++ b/test/test_lanhe.cc
@@ -69,7 +69,7 @@ void test_lanhe_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lanhe( norm2char(norm), uplo2char(uplo), n, &A[0], lda );
+        real_t norm_ref = LAPACKE_lanhe( to_char( norm ), to_char( uplo ), n, &A[0], lda );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lanhp.cc
+++ b/test/test_lanhp.cc
@@ -63,7 +63,7 @@ void test_lanhp_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lanhp( norm2char(norm), uplo2char(uplo), n, &AP[0] );
+        real_t norm_ref = LAPACKE_lanhp( to_char( norm ), to_char( uplo ), n, &AP[0] );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lanhs.cc
+++ b/test/test_lanhs.cc
@@ -67,7 +67,7 @@ void test_lanhs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lanhs( norm2char(norm), n, &A[0], lda );
+        real_t norm_ref = LAPACKE_lanhs( to_char( norm ), n, &A[0], lda );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lanht.cc
+++ b/test/test_lanht.cc
@@ -61,7 +61,7 @@ void test_lanht_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lanht( norm2char(norm), n, &D[0], &E[0] );
+        real_t norm_ref = LAPACKE_lanht( to_char( norm ), n, &D[0], &E[0] );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lansb.cc
+++ b/test/test_lansb.cc
@@ -66,7 +66,7 @@ void test_lansb_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lansb( norm2char(norm), uplo2char(uplo), n, kd, &AB[0], ldab );
+        real_t norm_ref = LAPACKE_lansb( to_char( norm ), to_char( uplo ), n, kd, &AB[0], ldab );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lansp.cc
+++ b/test/test_lansp.cc
@@ -63,7 +63,7 @@ void test_lansp_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lansp( norm2char(norm), uplo2char(uplo), n, &AP[0] );
+        real_t norm_ref = LAPACKE_lansp( to_char( norm ), to_char( uplo ), n, &AP[0] );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lanst.cc
+++ b/test/test_lanst.cc
@@ -62,7 +62,7 @@ void test_lanst_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lanst( norm2char(norm), n, &D[0], &E[0] );
+        real_t norm_ref = LAPACKE_lanst( to_char( norm ), n, &D[0], &E[0] );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lansy.cc
+++ b/test/test_lansy.cc
@@ -69,7 +69,7 @@ void test_lansy_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lansy( norm2char(norm), uplo2char(uplo), n, &A[0], lda );
+        real_t norm_ref = LAPACKE_lansy( to_char( norm ), to_char( uplo ), n, &A[0], lda );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lantb.cc
+++ b/test/test_lantb.cc
@@ -63,7 +63,7 @@ void test_lantb_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lantb( norm2char(norm), uplo2char(uplo), diag2char(diag), n, k, &AB[0], ldab );
+        real_t norm_ref = LAPACKE_lantb( to_char( norm ), to_char( uplo ), to_char( diag ), n, k, &AB[0], ldab );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lantp.cc
+++ b/test/test_lantp.cc
@@ -60,7 +60,7 @@ void test_lantp_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lantp( norm2char(norm), uplo2char(uplo), diag2char(diag), n, &AP[0] );
+        real_t norm_ref = LAPACKE_lantp( to_char( norm ), to_char( uplo ), to_char( diag ), n, &AP[0] );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_lantr.cc
+++ b/test/test_lantr.cc
@@ -74,7 +74,7 @@ void test_lantr_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        real_t norm_ref = LAPACKE_lantr( norm2char(norm), uplo2char(uplo), diag2char(diag), m, n, &A[0], lda );
+        real_t norm_ref = LAPACKE_lantr( to_char( norm ), to_char( uplo ), to_char( diag ), m, n, &A[0], lda );
         time = testsweeper::get_wtime() - time;
 
         params.ref_time() = time;

--- a/test/test_larf.cc
+++ b/test/test_larf.cc
@@ -72,7 +72,7 @@ void test_larf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_larf( side2char(side), m, n, &V[0], incv, tau, &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_larf( to_char( side ), m, n, &V[0], incv, tau, &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_larf returned error %lld\n", llong( info_ref ) );

--- a/test/test_larfb.cc
+++ b/test/test_larfb.cc
@@ -110,7 +110,7 @@ void test_larfb_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_larfb( side2char(side), op2char(trans), direction2char(direction), storev2char(storev), m, n, k, &V[0], ldv, &T[0], ldt, &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_larfb( to_char( side ), to_char( trans ), to_char( direction ), to_char( storev ), m, n, k, &V[0], ldv, &T[0], ldt, &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_larfb returned error %lld\n", llong( info_ref ) );

--- a/test/test_larfg.cc
+++ b/test/test_larfg.cc
@@ -23,7 +23,7 @@ void test_larfg_work( Params& params, bool run )
     // get & mark input values
     int64_t n = params.dim.n();
     int64_t incx = params.incx();
-    scalar_t alpha_tst = params.alpha();
+    scalar_t alpha_tst = params.alpha.get<scalar_t>();
     scalar_t alpha_ref = alpha_tst;
     int64_t verbose = params.verbose();
 

--- a/test/test_larfgp.cc
+++ b/test/test_larfgp.cc
@@ -25,8 +25,8 @@ void test_larfgp_work( Params& params, bool run )
     // get & mark input values
     int64_t n = params.dim.n();
     int64_t incx = params.incx();
-    scalar_t alpha_tst = params.alpha();
-    //scalar_t alpha_ref = params.alpha();
+    scalar_t alpha_tst = params.alpha.get<scalar_t>();
+    //scalar_t alpha_ref = params.alpha.get<scalar_t>();
     int64_t verbose = params.verbose();
 
     // mark non-standard output values

--- a/test/test_larft.cc
+++ b/test/test_larft.cc
@@ -126,7 +126,7 @@ void test_larft_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_larft( direction2char(direction), storev2char(storev), n, k, &V[0], ldv, &tau[0], &T_ref[0], ldt );
+        int64_t info_ref = LAPACKE_larft( to_char( direction ), to_char( storev ), n, k, &V[0], ldv, &tau[0], &T_ref[0], ldt );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_larft returned error %lld\n", llong( info_ref ) );

--- a/test/test_larfx.cc
+++ b/test/test_larfx.cc
@@ -71,7 +71,7 @@ void test_larfx_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_larfx( side2char(side), m, n, &V[0], tau, &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_larfx( to_char( side ), m, n, &V[0], tau, &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_larfx returned error %lld\n", llong( info_ref ) );

--- a/test/test_larfy.cc
+++ b/test/test_larfy.cc
@@ -69,7 +69,7 @@ void test_larfy_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_larfy( uplo2char(uplo), n, &V[0], incv, tau, &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_larfy( to_char( uplo ), n, &V[0], incv, tau, &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_larfy returned error %lld\n", llong( info_ref ) );

--- a/test/test_laset.cc
+++ b/test/test_laset.cc
@@ -22,8 +22,8 @@ void test_laset_work( Params& params, bool run )
     lapack::MatrixType matrixtype = params.matrixtype();
     int64_t m = params.dim.m();
     int64_t n = params.dim.n();
-    scalar_t alpha = params.alpha();
-    scalar_t beta = params.beta();
+    scalar_t alpha = params.alpha.get<scalar_t>();
+    scalar_t beta  = params.beta.get<scalar_t>();
     int64_t align = params.align();
     params.matrix.mark();
 
@@ -59,7 +59,7 @@ void test_laset_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_laset( matrixtype2char(matrixtype), m, n, alpha, beta, &A_ref[0], lda );
+        int64_t info_ref = LAPACKE_laset( to_char( matrixtype ), m, n, alpha, beta, &A_ref[0], lda );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_laset returned error %lld\n", llong( info_ref ) );

--- a/test/test_orhr_col.cc
+++ b/test/test_orhr_col.cc
@@ -53,23 +53,28 @@ void test_orhr_col_work( Params& params, bool run )
     // ---------- run test
     testsweeper::flush_cache( params.cache() );
     double time = testsweeper::get_wtime();
-    int64_t info_tst = lapack::orhr_col( m, n, nb, &A_tst[0], lda, &T_tst[0], ldt, &D_tst[0] );
+    int64_t info_tst = lapack::orhr_col(
+        m, n, nb, &A_tst[0], lda, &T_tst[0], ldt, &D_tst[0] );
     time = testsweeper::get_wtime() - time;
     if (info_tst != 0) {
-        fprintf( stderr, "lapack::orhr_col returned error %lld\n", llong( info_tst ) );
+        fprintf( stderr, "lapack::orhr_col returned error %lld\n",
+                 llong( info_tst ) );
     }
 
     params.time() = time;
 
-    #ifdef LAPACK_HAVE_MKL
     if (params.ref() == 'y' || params.check() == 'y') {
+    #if LAPACK_VERSION >= 31200 || defined( LAPACK_HAVE_MKL )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_orhr_col( m, n, nb, &A_ref[0], lda, &T_ref[0], ldt, &D_ref[0] );
+        // min works around bug in LAPACK <= 3.12
+        int64_t info_ref = LAPACKE_orhr_col(
+            m, n, blas::min( nb, n ), &A_ref[0], lda, &T_ref[0], ldt, &D_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
-            fprintf( stderr, "LAPACKE_orhr_col returned error %lld\n", llong( info_ref ) );
+            fprintf( stderr, "LAPACKE_orhr_col returned error %lld\n",
+                     llong( info_ref ) );
         }
 
         params.ref_time() = time;
@@ -84,11 +89,11 @@ void test_orhr_col_work( Params& params, bool run )
         error += abs_error( D_tst, D_ref );
         params.error() = error;
         params.okay() = (error == 0);  // expect lapackpp == lapacke
-    }
     #else
         // LAPACKE_unhr_col not yet in LAPACK
-        params.msg() = "check requires Intel MKL, as of LAPACK 3.11";
+        params.msg() = "check requires LAPACK >= 3.12 or Intel MKL";
     #endif  // LAPACK_HAVE_MKL
+    }
 }
 
 #endif  // LAPACK >= 3.9.0

--- a/test/test_pbcon.cc
+++ b/test/test_pbcon.cc
@@ -83,7 +83,7 @@ void test_pbcon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pbcon( uplo2char(uplo), n, kd, &AB[0], ldab, anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_pbcon( to_char( uplo ), n, kd, &AB[0], ldab, anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pbcon returned error %lld\n", llong( info_ref ) );

--- a/test/test_pbequ.cc
+++ b/test/test_pbequ.cc
@@ -78,7 +78,7 @@ void test_pbequ_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pbequ( uplo2char(uplo), n, kd, &AB[0], ldab, &S_ref[0], &scond_ref, &amax_ref );
+        int64_t info_ref = LAPACKE_pbequ( to_char( uplo ), n, kd, &AB[0], ldab, &S_ref[0], &scond_ref, &amax_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pbequ returned error %lld\n", llong( info_ref ) );

--- a/test/test_pbrfs.cc
+++ b/test/test_pbrfs.cc
@@ -154,7 +154,7 @@ void test_pbrfs_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_pbrfs(
-            uplo2char(uplo), n, kd, nrhs, &AB[0], ldab, &AFB[0], ldafb,
+            to_char( uplo ), n, kd, nrhs, &AB[0], ldab, &AFB[0], ldafb,
             &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {

--- a/test/test_pbsv.cc
+++ b/test/test_pbsv.cc
@@ -126,7 +126,7 @@ void test_pbsv_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pbsv( uplo2char(uplo), n, kd, nrhs, &AB_ref[0], ldab, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_pbsv( to_char( uplo ), n, kd, nrhs, &AB_ref[0], ldab, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pbsv returned error %lld\n", llong( info_ref ) );

--- a/test/test_pbtrf.cc
+++ b/test/test_pbtrf.cc
@@ -74,7 +74,7 @@ void test_pbtrf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pbtrf( uplo2char(uplo), n, kd, &AB_ref[0], ldab );
+        int64_t info_ref = LAPACKE_pbtrf( to_char( uplo ), n, kd, &AB_ref[0], ldab );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pbtrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_pbtrs.cc
+++ b/test/test_pbtrs.cc
@@ -132,7 +132,7 @@ void test_pbtrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pbtrs( uplo2char(uplo), n, kd, nrhs, &AB_tst[0], ldab, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_pbtrs( to_char( uplo ), n, kd, nrhs, &AB_tst[0], ldab, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pbtrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_pocon.cc
+++ b/test/test_pocon.cc
@@ -79,7 +79,7 @@ void test_pocon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pocon( uplo2char(uplo), n, &A[0], lda, anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_pocon( to_char( uplo ), n, &A[0], lda, anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pocon returned error %lld\n", llong( info_ref ) );

--- a/test/test_porfs.cc
+++ b/test/test_porfs.cc
@@ -97,7 +97,7 @@ void test_porfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_porfs( uplo2char(uplo), n, nrhs, &A[0], lda, &AF[0], ldaf, &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_porfs( to_char( uplo ), n, nrhs, &A[0], lda, &AF[0], ldaf, &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_porfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -122,7 +122,7 @@ void test_posv_work( Params& params, bool run )
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
         int64_t info_ref = LAPACKE_posv(
-            uplo2char(uplo), n, nrhs, &A_ref[0], lda, &B_ref[0], ldb );
+            to_char( uplo ), n, nrhs, &A_ref[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_posv returned error %lld\n", llong( info_ref ) );

--- a/test/test_potrf.cc
+++ b/test/test_potrf.cc
@@ -122,7 +122,7 @@ void test_potrf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_potrf( uplo2char(uplo), n, &A_ref[0], lda );
+        int64_t info_ref = LAPACKE_potrf( to_char( uplo ), n, &A_ref[0], lda );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_potrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_potrf_device.cc
+++ b/test/test_potrf_device.cc
@@ -151,7 +151,7 @@ void test_potrf_device_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_potrf( uplo2char(uplo), n, &A_ref[0], lda );
+        int64_t info_ref = LAPACKE_potrf( to_char( uplo ), n, &A_ref[0], lda );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_potrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_potri.cc
+++ b/test/test_potri.cc
@@ -136,7 +136,7 @@ void test_potri_work( Params& params, bool run )
 
     if (params.ref() == 'y') {
         // factor A into LL^T
-        info = LAPACKE_potrf( uplo2char(uplo), n, &A_ref[0], lda );
+        info = LAPACKE_potrf( to_char( uplo ), n, &A_ref[0], lda );
         if (info != 0) {
             fprintf( stderr, "LAPACKE_potrf returned error %lld\n", llong( info ) );
         }
@@ -144,7 +144,7 @@ void test_potri_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_potri( uplo2char(uplo), n, &A_ref[0], lda );
+        int64_t info_ref = LAPACKE_potri( to_char( uplo ), n, &A_ref[0], lda );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_potri returned error %lld\n", llong( info_ref ) );

--- a/test/test_potrs.cc
+++ b/test/test_potrs.cc
@@ -101,7 +101,7 @@ void test_potrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_potrs( uplo2char(uplo), n, nrhs, &A[0], lda, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_potrs( to_char( uplo ), n, nrhs, &A[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_potrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_ppcon.cc
+++ b/test/test_ppcon.cc
@@ -81,7 +81,7 @@ void test_ppcon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_ppcon( uplo2char(uplo), n, &AP[0], anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_ppcon( to_char( uplo ), n, &AP[0], anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_ppcon returned error %lld\n", llong( info_ref ) );

--- a/test/test_ppequ.cc
+++ b/test/test_ppequ.cc
@@ -75,7 +75,7 @@ void test_ppequ_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_ppequ( uplo2char(uplo), n, &AP[0], &S_ref[0], &scond_ref, &amax_ref );
+        int64_t info_ref = LAPACKE_ppequ( to_char( uplo ), n, &AP[0], &S_ref[0], &scond_ref, &amax_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_ppequ returned error %lld\n", llong( info_ref ) );

--- a/test/test_pprfs.cc
+++ b/test/test_pprfs.cc
@@ -105,7 +105,7 @@ void test_pprfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pprfs( uplo2char(uplo), n, nrhs, &AP[0], &AFP[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_pprfs( to_char( uplo ), n, nrhs, &AP[0], &AFP[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pprfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_ppsv.cc
+++ b/test/test_ppsv.cc
@@ -78,7 +78,7 @@ void test_ppsv_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_ppsv( uplo2char(uplo), n, nrhs, &AP_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_ppsv( to_char( uplo ), n, nrhs, &AP_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_ppsv returned error %lld\n", llong( info_ref ) );

--- a/test/test_pptrf.cc
+++ b/test/test_pptrf.cc
@@ -70,7 +70,7 @@ void test_pptrf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pptrf( uplo2char(uplo), n, &AP_ref[0] );
+        int64_t info_ref = LAPACKE_pptrf( to_char( uplo ), n, &AP_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pptrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_pptri.cc
+++ b/test/test_pptri.cc
@@ -77,7 +77,7 @@ void test_pptri_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pptri( uplo2char(uplo), n, &AP_ref[0] );
+        int64_t info_ref = LAPACKE_pptri( to_char( uplo ), n, &AP_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pptri returned error %lld\n", llong( info_ref ) );

--- a/test/test_pptrs.cc
+++ b/test/test_pptrs.cc
@@ -82,7 +82,7 @@ void test_pptrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pptrs( uplo2char(uplo), n, nrhs, &AP[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_pptrs( to_char( uplo ), n, nrhs, &AP[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pptrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_ptrfs.cc
+++ b/test/test_ptrfs.cc
@@ -100,7 +100,7 @@ void test_ptrfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_ptrfs( uplo2char(uplo), n, nrhs, &D[0], &E[0], &DF[0], &EF[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_ptrfs( to_char( uplo ), n, nrhs, &D[0], &E[0], &DF[0], &EF[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_ptrfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_pttrs.cc
+++ b/test/test_pttrs.cc
@@ -77,7 +77,7 @@ void test_pttrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_pttrs( uplo2char(uplo), n, nrhs, &D[0], &E[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_pttrs( to_char( uplo ), n, nrhs, &D[0], &E[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_pttrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_spcon.cc
+++ b/test/test_spcon.cc
@@ -72,7 +72,7 @@ void test_spcon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_spcon( uplo2char(uplo), n, &AP[0], &ipiv_ref[0], anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_spcon( to_char( uplo ), n, &AP[0], &ipiv_ref[0], anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_spcon returned error %lld\n", llong( info_ref ) );

--- a/test/test_sprfs.cc
+++ b/test/test_sprfs.cc
@@ -95,7 +95,7 @@ void test_sprfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sprfs( uplo2char(uplo), n, nrhs, &AP[0], &AFP[0], &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_sprfs( to_char( uplo ), n, nrhs, &AP[0], &AFP[0], &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sprfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_spsv.cc
+++ b/test/test_spsv.cc
@@ -79,7 +79,7 @@ void test_spsv_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_spsv( uplo2char(uplo), n, nrhs, &AP_ref[0], &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_spsv( to_char( uplo ), n, nrhs, &AP_ref[0], &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_spsv returned error %lld\n", llong( info_ref ) );

--- a/test/test_sptrf.cc
+++ b/test/test_sptrf.cc
@@ -61,7 +61,7 @@ void test_sptrf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sptrf( uplo2char(uplo), n, &AP_ref[0], &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_sptrf( to_char( uplo ), n, &AP_ref[0], &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sptrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_sptri.cc
+++ b/test/test_sptri.cc
@@ -72,7 +72,7 @@ void test_sptri_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sptri( uplo2char(uplo), n, &AP_ref[0], &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_sptri( to_char( uplo ), n, &AP_ref[0], &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sptri returned error %lld\n", llong( info_ref ) );

--- a/test/test_sptrs.cc
+++ b/test/test_sptrs.cc
@@ -79,7 +79,7 @@ void test_sptrs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sptrs( uplo2char(uplo), n, nrhs, &AP[0], &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sptrs( to_char( uplo ), n, nrhs, &AP[0], &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sptrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_sycon.cc
+++ b/test/test_sycon.cc
@@ -70,7 +70,7 @@ void test_sycon_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sycon( uplo2char(uplo), n, &A[0], lda, &ipiv_ref[0], anorm, &rcond_ref );
+        int64_t info_ref = LAPACKE_sycon( to_char( uplo ), n, &A[0], lda, &ipiv_ref[0], anorm, &rcond_ref );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sycon returned error %lld\n", llong( info_ref ) );

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -23,8 +23,8 @@ void test_symv_work( Params& params, bool run )
     // get & mark input values
     blas::Layout layout = params.layout();
     blas::Uplo uplo = params.uplo();
-    scalar_t alpha  = params.alpha();
-    scalar_t beta   = params.beta();
+    scalar_t alpha  = params.alpha.get<scalar_t>();
+    scalar_t beta   = params.beta.get<scalar_t>();
     int64_t n       = params.dim.n();
     int64_t incx    = params.incx();
     int64_t incy    = params.incy();

--- a/test/test_syr.cc
+++ b/test/test_syr.cc
@@ -28,7 +28,7 @@ void test_syr_work( Params& params, bool run )
     // get & mark input values
     blas::Layout layout = params.layout();
     blas::Uplo uplo = params.uplo();
-    scalar_t alpha  = params.alpha();
+    scalar_t alpha  = params.alpha.get<scalar_t>();
     int64_t n       = params.dim.n();
     int64_t incx    = params.incx();
     int64_t align   = params.align();

--- a/test/test_syrfs.cc
+++ b/test/test_syrfs.cc
@@ -96,7 +96,7 @@ void test_syrfs_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_syrfs( uplo2char(uplo), n, nrhs, &A[0], lda, &AF[0], ldaf, &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
+        int64_t info_ref = LAPACKE_syrfs( to_char( uplo ), n, nrhs, &A[0], lda, &AF[0], ldaf, &ipiv_ref[0], &B[0], ldb, &X_ref[0], ldx, &ferr_ref[0], &berr_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_syrfs returned error %lld\n", llong( info_ref ) );

--- a/test/test_sysv.cc
+++ b/test/test_sysv.cc
@@ -71,7 +71,7 @@ void test_sysv_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sysv( uplo2char(uplo), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sysv( to_char( uplo ), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sysv returned error %lld\n", llong( info_ref ) );

--- a/test/test_sysv_aa.cc
+++ b/test/test_sysv_aa.cc
@@ -82,7 +82,7 @@ void test_sysv_aa_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sysv_aa( uplo2char(uplo), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sysv_aa( to_char( uplo ), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sysv_aa returned error %lld\n", llong( info_ref ) );

--- a/test/test_sysv_rk.cc
+++ b/test/test_sysv_rk.cc
@@ -80,7 +80,7 @@ void test_sysv_rk_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sysv_rk( uplo2char(uplo), n, nrhs, &A_ref[0], lda, &E_ref[0], &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sysv_rk( to_char( uplo ), n, nrhs, &A_ref[0], lda, &E_ref[0], &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sysv_rk returned error %lld\n", llong( info_ref ) );

--- a/test/test_sysv_rook.cc
+++ b/test/test_sysv_rook.cc
@@ -77,7 +77,7 @@ void test_sysv_rook_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sysv_rook( uplo2char(uplo), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sysv_rook( to_char( uplo ), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sysv_rook returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytrf.cc
+++ b/test/test_sytrf.cc
@@ -62,7 +62,7 @@ void test_sytrf_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytrf( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_sytrf( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytrf returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytrf_aa.cc
+++ b/test/test_sytrf_aa.cc
@@ -69,7 +69,7 @@ void test_sytrf_aa_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytrf_aa( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_sytrf_aa( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytrf_aa returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytrf_rk.cc
+++ b/test/test_sytrf_rk.cc
@@ -71,7 +71,7 @@ void test_sytrf_rk_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytrf_rk( uplo2char(uplo), n, &A_ref[0], lda, &E_ref[0], &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_sytrf_rk( to_char( uplo ), n, &A_ref[0], lda, &E_ref[0], &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytrf_rk returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytrf_rook.cc
+++ b/test/test_sytrf_rook.cc
@@ -68,7 +68,7 @@ void test_sytrf_rook_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytrf_rook( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_sytrf_rook( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytrf_rook returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytri.cc
+++ b/test/test_sytri.cc
@@ -70,14 +70,14 @@ void test_sytri_work( Params& params, bool run )
 
     if (params.ref() == 'y' || params.check() == 'y') {
         // ---------- factor
-        info = LAPACKE_sytrf( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        info = LAPACKE_sytrf( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         if (info != 0) {
             fprintf( stderr, "LAPACKE_sytrf returned error %lld\n", llong( info ) );
         }
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytri( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        int64_t info_ref = LAPACKE_sytri( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytri returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytrs.cc
+++ b/test/test_sytrs.cc
@@ -79,14 +79,14 @@ void test_sytrs_work( Params& params, bool run )
 
     if (params.ref() == 'y' || params.check() == 'y') {
         // ---------- factor
-        info = LAPACKE_sytrf( uplo2char(uplo), n, &A_ref[0], lda, &ipiv_ref[0] );
+        info = LAPACKE_sytrf( to_char( uplo ), n, &A_ref[0], lda, &ipiv_ref[0] );
         if (info != 0) {
             fprintf( stderr, "LAPACKE_sytrf returned error %lld\n", llong( info ) );
         }
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytrs( uplo2char(uplo), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sytrs( to_char( uplo ), n, nrhs, &A_ref[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytrs returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytrs_aa.cc
+++ b/test/test_sytrs_aa.cc
@@ -78,7 +78,7 @@ void test_sytrs_aa_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytrs_aa( uplo2char(uplo), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sytrs_aa( to_char( uplo ), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytrs_aa returned error %lld\n", llong( info_ref ) );

--- a/test/test_sytrs_rook.cc
+++ b/test/test_sytrs_rook.cc
@@ -82,7 +82,7 @@ void test_sytrs_rook_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_sytrs_rook( uplo2char(uplo), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_sytrs_rook( to_char( uplo ), n, nrhs, &A[0], lda, &ipiv_ref[0], &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_sytrs_rook returned error %lld\n", llong( info_ref ) );

--- a/test/test_tpmlqt.cc
+++ b/test/test_tpmlqt.cc
@@ -128,7 +128,7 @@ void test_tpmlqt_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_tpmlqt( side2char(side), op2char(trans), m, n, k, l, nb, &V[0], ldv, &T[0], ldt, &A_ref[0], lda, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_tpmlqt( to_char( side ), to_char( trans ), m, n, k, l, nb, &V[0], ldv, &T[0], ldt, &A_ref[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_tpmlqt returned error %lld\n", llong( info_ref ) );

--- a/test/test_tpmqrt.cc
+++ b/test/test_tpmqrt.cc
@@ -149,7 +149,7 @@ void test_tpmqrt_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_tpmqrt( side2char(side), op2char(trans), m, n, k, l, nb, &V[0], ldv, &T[0], ldt, &A_ref[0], lda, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_tpmqrt( to_char( side ), to_char( trans ), m, n, k, l, nb, &V[0], ldv, &T[0], ldt, &A_ref[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_tpmqrt returned error %lld\n", llong( info_ref ) );

--- a/test/test_tprfb.cc
+++ b/test/test_tprfb.cc
@@ -109,7 +109,7 @@ void test_tprfb_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_tprfb( side2char(side), op2char(trans), direction2char(direction), storev2char(storev), m, n, k, l, &V[0], ldv, &T[0], ldt, &A_ref[0], lda, &B_ref[0], ldb );
+        int64_t info_ref = LAPACKE_tprfb( to_char( side ), to_char( trans ), to_char( direction ), to_char( storev ), m, n, k, l, &V[0], ldv, &T[0], ldt, &A_ref[0], lda, &B_ref[0], ldb );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_tprfb returned error %lld\n", llong( info_ref ) );

--- a/test/test_ungtr.cc
+++ b/test/test_ungtr.cc
@@ -77,7 +77,7 @@ void test_ungtr_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_ungtr( uplo2char(uplo), n, &A_ref[0], lda, &tau[0] );
+        int64_t info_ref = LAPACKE_ungtr( to_char( uplo ), n, &A_ref[0], lda, &tau[0] );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_ungtr returned error %lld\n", llong( info_ref ) );

--- a/test/test_unmhr.cc
+++ b/test/test_unmhr.cc
@@ -89,7 +89,7 @@ void test_unmhr_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_unmhr( side2char(side), op2char(trans), m, n, ilo, ihi, &A[0], lda, &tau[0], &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_unmhr( to_char( side ), to_char( trans ), m, n, ilo, ihi, &A[0], lda, &tau[0], &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_unmhr returned error %lld\n", llong( info_ref ) );

--- a/test/test_unmtr.cc
+++ b/test/test_unmtr.cc
@@ -85,7 +85,7 @@ void test_unmtr_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_unmtr( side2char(side), uplo2char(uplo), op2char(trans), m, n, &A[0], lda, &tau[0], &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_unmtr( to_char( side ), to_char( uplo ), to_char( trans ), m, n, &A[0], lda, &tau[0], &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_unmtr returned error %lld\n", llong( info_ref ) );

--- a/test/test_upgtr.cc
+++ b/test/test_upgtr.cc
@@ -78,7 +78,7 @@ void test_upgtr_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_upgtr( uplo2char(uplo), n, &AP[0], &tau[0], &Q_ref[0], ldq );
+        int64_t info_ref = LAPACKE_upgtr( to_char( uplo ), n, &AP[0], &tau[0], &Q_ref[0], ldq );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_upgtr returned error %lld\n", llong( info_ref ) );

--- a/test/test_upmtr.cc
+++ b/test/test_upmtr.cc
@@ -83,7 +83,7 @@ void test_upmtr_work( Params& params, bool run )
         // ---------- run reference
         testsweeper::flush_cache( params.cache() );
         time = testsweeper::get_wtime();
-        int64_t info_ref = LAPACKE_upmtr( side2char(side), uplo2char(uplo), op2char(trans), m, n, &AP[0], &tau[0], &C_ref[0], ldc );
+        int64_t info_ref = LAPACKE_upmtr( to_char( side ), to_char( uplo ), to_char( trans ), m, n, &AP[0], &tau[0], &C_ref[0], ldc );
         time = testsweeper::get_wtime() - time;
         if (info_ref != 0) {
             fprintf( stderr, "LAPACKE_upmtr returned error %lld\n", llong( info_ref ) );


### PR DESCRIPTION
Depends on https://github.com/icl-utk-edu/testsweeper/pull/21 and https://github.com/icl-utk-edu/blaspp/pull/77

Use standard `to_string` function to convert enum to string.
Introduce `to_char` and `to_c_string` functions.
Introduce `from_string` function to convert string to enum.
This also makes the ParamEnum constructor much simpler.

Changing the blocksize nb to match SLATE had the side effect of revealing a [bug in orhr_col and unhr_col](https://github.com/Reference-LAPACK/lapack/pull/1018). A work around was added.