### PR TITLE
deprecate lapy2, lapy3; use std::hypot

### DIFF
--- a/include/lapack/wrappers.hh
+++ b/include/lapack/wrappers.hh
@@ -4085,16 +4085,20 @@ void lapmt(
     int64_t* K );
 
 // -----------------------------------------------------------------------------
+[[deprecated("use std::hypot. To be removed 2025-06.")]]
 float lapy2(
     float x, float y );
 
+[[deprecated("use std::hypot. To be removed 2025-06.")]]
 double lapy2(
     double x, double y );
 
 // -----------------------------------------------------------------------------
+[[deprecated("use std::hypot (C++17). To be removed 2025-06.")]]
 float lapy3(
     float x, float y, float z );
 
+[[deprecated("use std::hypot (C++17). To be removed 2025-06.")]]
 double lapy3(
     double x, double y, double z );
 

--- a/src/lapy2.cc
+++ b/src/lapy2.cc
@@ -27,7 +27,7 @@ float lapy2(
 /// overflow.
 ///
 /// Overloaded versions are available for
-/// `float`, `double`, `std::complex<float>`, and `std::complex<double>`.
+/// `float`, `double`.
 ///
 /// @param[in] x
 ///

--- a/src/lapy3.cc
+++ b/src/lapy3.cc
@@ -27,7 +27,7 @@ float lapy3(
 /// unnecessary overflow.
 ///
 /// Overloaded versions are available for
-/// `float`, `double`, `std::complex<float>`, and `std::complex<double>`.
+/// `float`, `double`.
 ///
 /// @param[in] x
 ///

--- a/test/check_geev.hh
+++ b/test/check_geev.hh
@@ -119,8 +119,8 @@ real_t check_geev_Vnormalization(
                 require( real( W[j] ) ==  real( W[j+1] ) );
                 require( imag( W[j] ) == -imag( W[j+1] ) );
                 ipair = true;
-                nrm = lapack::lapy2( blas::nrm2( n, &V(0,j  ), 1 ),
-                                     blas::nrm2( n, &V(0,j+1), 1 ) );
+                nrm = std::hypot( blas::nrm2( n, &V( 0, j   ), 1 ),
+                                  blas::nrm2( n, &V( 0, j+1 ), 1 ) );
             }
             else {
                 // real eigenvector
@@ -133,7 +133,7 @@ real_t check_geev_Vnormalization(
                 real_t Vmax = 0;
                 real_t Vrmax = 0;
                 for (int64_t i = 0; i < n; ++i) {
-                    real_t tmp = lapack::lapy2( V(i,j), V(i,j+1) );
+                    real_t tmp = std::hypot( V( i, j ), V( i, j+1 ) );
                     if (tmp > Vmax)
                         Vmax = tmp;
                     if (V(i,j+1) == 0 && std::abs( V(i,j) ) > Vrmax)


### PR DESCRIPTION
Prefer `std` routine with a better name.