### PR TITLE
Add missing direct includes for MSVC builds (stdint.h, complex)

### DIFF
--- a/include/lapack/config.h
+++ b/include/lapack/config.h
@@ -10,6 +10,7 @@
 #include "lapack/defines.h"
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #if defined(BLAS_ILP64) && ! defined(LAPACK_ILP64)
     #define LAPACK_ILP64

--- a/src/lartg.cc
+++ b/src/lartg.cc
@@ -5,6 +5,8 @@
 
 #include "lapack/fortran.h"
 
+#include <complex>
+
 namespace lapack {
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Building LAPACK++ natively with MSVC fails in the ILP64 configuration with diagnostics beginning:

```text
include/lapack/config.h(20): error C4430: missing type specifier
include/lapack/config.h(20): error C2146: missing ';' before identifier 'lapack_int'
include/lapack/fortran.h(35): error C2065: 'LAPACK_S_SELECT2': undeclared identifier
src/lartg.cc(36): error C2039: 'complex': is not a member of 'std'
```

Two independent missing direct includes:

1. `include/lapack/config.h` uses global `int64_t` for `lapack_int` when `LAPACK_ILP64` is enabled, but does not include `<stdint.h>`. Unix standard-library headers expose the type transitively through `<stdlib.h>`; MSVC's does not. The `LAPACK_S_SELECT2` / callback errors cascade from the failed `lapack_int` typedef.
2. `src/lartg.cc` uses `std::complex` but does not include `<complex>`. Under MSVC, the `_MSC_VER` branch in `lapack/config.h` defines C-compatible complex structs and never pulls in the C++ `<complex>` header.

This PR includes both headers directly rather than relying on transitive implementation details of a particular standard library.

Context: found during the RandBLAS native-Windows port ([BallisticLA/RandBLAS#179](https://github.com/BallisticLA/RandBLAS/pull/179)) by Raphael A. Meyer (@RaphaelArkadyMeyerNYU); RandBLAS Windows CI (MSVC 19.51, oneMKL ILP64 sequential, NMake) has been building LAPACK++ with exactly these two includes since 2026-07 via a temporary fork branch. Environment tested there: Windows x64, MSVC 19.51, C++17, LAPACK++ 2025.05.28 (commit 8b32767).
